### PR TITLE
chore: enable lazy loading for images

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -95,6 +95,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <div class="h-full w-full overflow-hidden">
                     <img src="${imageBasePath}${imageInfo.filename}"
                          alt="${imageInfo.title}"
+                         loading="lazy"
                          class="w-full h-full object-cover object-left hover:scale-105 transition-transform duration-500 cursor-move"
                          onerror="console.log('Failed to load image:', this.src)">
                 </div>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
             <nav class="glass-card py-3 px-6 flex flex-col md:flex-row md:justify-between md:items-center">
                 <div class="flex items-center space-x-2">
                     <div class="bg-indigo-500 rounded-lg p-1.5">
-                        <img src="logoTransp.png" alt="MAI logo" class="w-5 h-5">
+                        <img src="logoTransp.png" alt="MAI logo" class="w-5 h-5" loading="lazy">
                     </div>
                     <span class="font-bold text-xl tracking-wide">MUSEUM OF ARTIFICIAL INTELLIGENCE</span>
                     <div class="flex items-center ml-3 space-x-2">
@@ -440,7 +440,7 @@ The Museum of Artificial Intelligence's mission is to inform, teach, and promote
                         <div class="glass-card p-6 rounded-2xl border border-slate-700 w-full max-w-md">
                             <h3 class="text-xl font-bold mb-4 text-center">Members Preview</h3>
                             <div class="bg-gradient-to-r from-black/80 to-black/80 h-48 rounded-xl flex items-center justify-center border border-slate-700 mb-4">
-                                <img src="logo2.png" alt="MAI logo" class="h-48 w-48 object-contain rounded-xl">
+                                <img src="logo2.png" alt="MAI logo" class="h-48 w-48 object-contain rounded-xl" loading="lazy">
                             </div>
                             <p class="text-center text-slate-300">Members get exclusive early access to our "Vibe Coding" workshops starting in March 2026.</p>
                         </div>
@@ -457,7 +457,7 @@ The Museum of Artificial Intelligence's mission is to inform, teach, and promote
                 <div class="md:col-span-2">
                     <div class="flex items-center space-x-3 mb-6">
                         <div class="bg-indigo-600 rounded-lg p-1.5">
-                            <img src="logoTransp.png" alt="MAI logo" class="w-5 h-5">
+                            <img src="logoTransp.png" alt="MAI logo" class="w-5 h-5" loading="lazy">
                         </div>
                         <span class="font-bold text-xl">MUSEUM OF AI</span>
                     </div>

--- a/pages/journal.html
+++ b/pages/journal.html
@@ -21,7 +21,7 @@
       <nav class="glass-card py-3 px-6 flex flex-col md:flex-row md:justify-between md:items-center">
         <div class="flex items-center space-x-2">
           <div class="bg-indigo-500 rounded-lg p-1.5">
-            <img src="../logoTransp.png" alt="MAI logo" class="w-5 h-5">
+            <img src="../logoTransp.png" alt="MAI logo" class="w-5 h-5" loading="lazy">
           </div>
           <span class="font-bold text-xl tracking-wide">MUSEUM OF ARTIFICIAL INTELLIGENCE</span>
         </div>
@@ -106,7 +106,7 @@
             <article class="blog-card glass-card rounded-xl overflow-hidden transition duration-500 hover:shadow-xl">
               <a href="${tracked}" target="_blank" rel="noopener">
                 <div class="${img ? '' : 'bg-gradient-to-br from-indigo-700/40 to-cyan-600/30'}">
-                  ${img ? `<img src="${img}" alt="${title}" class="w-full h-48 object-cover">` : `<div class="h-48"></div>`}
+                  ${img ? `<img src="${img}" alt="${title}" class="w-full h-48 object-cover" loading="lazy">` : `<div class="h-48"></div>`}
                 </div>
                 <div class="p-6">
                   <div class="text-indigo-300 text-xs font-semibold mb-2">${date}</div>
@@ -150,7 +150,7 @@
       <nav class="glass-card py-3 px-6 flex flex-col md:flex-row md:justify-between md:items-center">
         <div class="flex items-center space-x-2">
           <div class="bg-indigo-500 rounded-lg p-1.5">
-            <img src="logoTransp.png" alt="MAI logo" class="w-5 h-5">
+            <img src="logoTransp.png" alt="MAI logo" class="w-5 h-5" loading="lazy">
           </div>
           <span class="font-bold text-xl tracking-wide">MUSEUM OF ARTIFICIAL INTELLIGENCE</span>
         </div>
@@ -236,7 +236,7 @@
             <article class="blog-card glass-card rounded-xl overflow-hidden transition duration-500 hover:shadow-xl">
               <a href="${tracked}" target="_blank" rel="noopener">
                 <div class="${img ? '' : 'bg-gradient-to-br from-indigo-700/40 to-cyan-600/30'}">
-                  ${img ? `<img src="${img}" alt="${title}" class="w-full h-48 object-cover">` : `<div class="h-48"></div>`}
+                  ${img ? `<img src="${img}" alt="${title}" class="w-full h-48 object-cover" loading="lazy">` : `<div class="h-48"></div>`}
                 </div>
                 <div class="p-6">
                   <div class="text-indigo-300 text-xs font-semibold mb-2">${date}</div>

--- a/pages/membership.html
+++ b/pages/membership.html
@@ -82,7 +82,7 @@
 
     <div class="mt-8 flex justify-center">
       <img src="../images/WEBP_images/18-evenemang-at-narkesgatan.webp" alt="Evenemang at Närkegatan"
-           class="max-w-full rounded-xl border border-slate-700 shadow-lg">
+           class="max-w-full rounded-xl border border-slate-700 shadow-lg" loading="lazy">
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to images in static HTML pages
- lazy-load dynamically created slideshow images

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: postcss: not found)*
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b6a3a48754832fb7d10282c24d9b9a