### PR TITLE
chore: set Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
-  "cleanUrls": true
+  "cleanUrls": true,
+  "outputDirectory": "."
 }
 


### PR DESCRIPTION
## Summary
- ensure Vercel deploy uses repository root for output directory

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx vercel --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vercel)*

------
https://chatgpt.com/codex/tasks/task_e_68b6afd95e60832faaa8a8d5c441b181