### PR TITLE
Agent groundwork for admin dashboard: repo-driven prompts, settings, usage log

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -28,6 +28,35 @@ cards by `tools/inject-daily.js`:
 Posts land in `src/content/daily/` and are rendered by the existing build
 into `pages/daily.html` (index) and `pages/daily/<date>-<type>.html`.
 
+## Prompts, settings, and usage log (repo-driven)
+
+Three things are read from the **working repo clone** (not the agent image)
+at job time, so committing a change to `main` reconfigures the agent on its
+next run with no redeploy:
+
+- **Prompts** — `agent/prompts/*.md`. The daily-job prompts
+  (`on-this-day.md`, `ai-news.md`, shared fragments under `shared/`) and the
+  Telegram editor's system prompt (`editor-system.md`). `{{placeholders}}`
+  are filled in by `agent/prompts.js`; an unknown placeholder throws rather
+  than publishing a broken post.
+- **Settings** — `agent/settings.json`. Per-job provider/model
+  (`generation.onthisday`, `generation.ainews`; provider `anthropic` or
+  `openrouter`), the editor model (`editorModel`), and the price table used
+  for cost logging. Empty strings mean "fall back to the env vars"
+  (`ANTHROPIC_MODEL`, `OPENROUTER_MODEL`), which preserves the original
+  behavior when the file is absent.
+- **Usage log** — every LLM call appends one JSON line to
+  `reports/llm-usage.jsonl` (timestamp, job, provider, model, tokens,
+  searches, estimated USD cost) and it is committed together with the post
+  or edit it belongs to. OpenRouter calls log the exact cost reported by
+  OpenRouter; Anthropic calls compute cost from the `prices` table in
+  `agent/settings.json` (web search billed at `webSearchPer1000`, currently
+  $10/1000 searches).
+
+These three are the groundwork for the planned desktop admin dashboard
+(see `docs/DASHBOARD_PLAN.md`): the dashboard edits/commits these files and
+charts the usage log, without any server-side admin surface.
+
 ## Safety model
 
 - The agent pushes to `AGENT_BRANCH`. In production (since July 2026)

--- a/agent/editor.js
+++ b/agent/editor.js
@@ -5,6 +5,9 @@ const path = require('path');
 const { execFile } = require('child_process');
 const Anthropic = require('@anthropic-ai/sdk');
 const { config } = require('./config');
+const prompts = require('./prompts');
+const settings = require('./settings');
+const usage = require('./usage');
 
 const EDITABLE_PREFIXES = ['src/', 'docs/'];
 const MAX_TURNS = 30;
@@ -130,43 +133,38 @@ async function execTool(name, input) {
   }
 }
 
-const SYSTEM = `You are the website editing agent for the Museum of Artificial Intelligence (aimuseum.se).
-You edit the site's source files based on instructions the museum staff send via Telegram.
-
-Repository conventions:
-- src/site/ holds hand-authored HTML (including the home pages src/site/index.html in English and src/site/sv/index.html in Swedish), CSS, JS, and images. The site is bilingual: when you change user-visible text on one home page, make the equivalent change on the other language's page.
-- src/content/pages/*.js are build modules pairing EN/SV HTML partials (in the same directory) with templates in src/templates/pages/. Daily generated posts live in src/content/daily/.
-- public/ is build output — never edit it (you cannot; it is outside your allowed paths).
-- Styling is Tailwind CSS utility classes plus src/site/assets/css/styles.css. Match the existing look (glass-card, section-title, slate/cyan/indigo palette).
-
-Working method:
-1. Locate the right file(s) with list_files/read_file before writing.
-2. Make the smallest change that fulfils the instruction; preserve surrounding markup and formatting.
-3. Run run_build to validate after your edits.
-4. Finish with a short plain-text summary of what you changed and in which files. If the instruction is ambiguous or risky, say so in the summary instead of guessing wildly.
-
-You cannot run git; committing and pushing happens automatically after you finish.`;
-
-// Returns { summary, turns }.
+// Returns { summary, turns }. The system prompt lives in
+// agent/prompts/editor-system.md and the model in agent/settings.json — both
+// read from the repo clone at call time, so committed changes apply to the
+// next instruction without a redeploy.
 async function runEditInstruction(instruction, { onProgress } = {}) {
   const client = anthropic();
+  const system = prompts.render('editor-system');
+  const model = settings.editorModel();
   const messages = [{ role: 'user', content: instruction }];
   let summary = '';
+  let inputTokens = 0;
+  let outputTokens = 0;
+  const recordUsage = (turns) =>
+    usage.record({ job: 'edit', provider: 'anthropic', model, inputTokens, outputTokens, turns });
 
   for (let turn = 0; turn < MAX_TURNS; turn++) {
     const response = await client.messages.create({
-      model: config.model,
+      model,
       max_tokens: 16000,
-      system: SYSTEM,
+      system,
       tools: TOOLS,
       messages,
     });
+    inputTokens += response.usage?.input_tokens || 0;
+    outputTokens += response.usage?.output_tokens || 0;
 
     const toolUses = response.content.filter((b) => b.type === 'tool_use');
     const texts = response.content.filter((b) => b.type === 'text').map((b) => b.text);
 
     if (toolUses.length === 0) {
       summary = texts.join('\n').trim();
+      recordUsage(turn + 1);
       return { summary, turns: turn + 1 };
     }
 
@@ -185,6 +183,7 @@ async function runEditInstruction(instruction, { onProgress } = {}) {
     messages.push({ role: 'user', content: results });
   }
 
+  recordUsage(MAX_TURNS);
   return { summary: summary || 'Stopped after reaching the tool-use turn limit.', turns: MAX_TURNS };
 }
 

--- a/agent/jobs.js
+++ b/agent/jobs.js
@@ -7,6 +7,9 @@ const path = require('path');
 const Anthropic = require('@anthropic-ai/sdk');
 const { config } = require('./config');
 const gitrepo = require('./gitrepo');
+const prompts = require('./prompts');
+const settings = require('./settings');
+const usage = require('./usage');
 
 const DAILY_DIR = () => path.join(config.repoDir, 'src', 'content', 'daily');
 
@@ -14,29 +17,41 @@ function anthropic() {
   return new Anthropic({ apiKey: config.anthropicApiKey });
 }
 
-// Generation backend for the two content jobs: Anthropic (config.model) by
-// default; OpenRouter when OPENROUTER_MODEL is set (cost experiment).
-// Returns the reply text.
-async function generate(prompt, { search = false } = {}) {
-  if (config.openRouterModel) return generateOpenRouter(prompt, { search });
+// Generation backend for the two content jobs. Provider + model come from
+// agent/settings.json (falling back to ANTHROPIC_MODEL / OPENROUTER_MODEL env
+// vars — see agent/settings.js). Records token usage to reports/llm-usage.jsonl
+// and returns the reply text.
+async function generate(prompt, { search = false, job } = {}) {
+  const gen = settings.generationFor(job);
+  if (gen.provider === 'openrouter') return generateOpenRouter(gen.model, prompt, { search, job });
   const client = anthropic();
   // Adaptive thinking is on by default and counts against max_tokens,
   // so leave generous headroom or the reply is all thinking and no text.
   const response = await client.messages.create({
-    model: config.model,
+    model: gen.model,
     max_tokens: 16000,
     ...(search ? { tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: 8 }] } : {}),
     messages: [{ role: 'user', content: prompt }],
   });
+  usage.record({
+    job,
+    provider: 'anthropic',
+    model: gen.model,
+    inputTokens: response.usage?.input_tokens || 0,
+    outputTokens: response.usage?.output_tokens || 0,
+    searches: response.usage?.server_tool_use?.web_search_requests || 0,
+  });
   return response.content.filter((b) => b.type === 'text').map((b) => b.text).join('\n');
 }
 
-async function generateOpenRouter(prompt, { search = false } = {}) {
-  if (!config.openRouterApiKey) throw new Error('OPENROUTER_MODEL is set but OPENROUTER_API_KEY is missing');
+async function generateOpenRouter(model, prompt, { search = false, job } = {}) {
+  if (!config.openRouterApiKey) throw new Error('OpenRouter model configured but OPENROUTER_API_KEY is missing');
   const body = {
-    model: config.openRouterModel,
+    model,
     max_tokens: 16000,
     messages: [{ role: 'user', content: prompt }],
+    // Ask OpenRouter to report token counts and cost on the response.
+    usage: { include: true },
   };
   // OpenRouter web plugin (Exa): ~$0.005/request for up to 10 results,
   // injected into context and cited via url_citation annotations.
@@ -58,6 +73,14 @@ async function generateOpenRouter(prompt, { search = false } = {}) {
   const data = await resp.json();
   const text = data.choices?.[0]?.message?.content;
   if (!text) throw new Error(`OpenRouter reply contained no content (finish: ${data.choices?.[0]?.finish_reason || 'unknown'})`);
+  usage.record({
+    job,
+    provider: 'openrouter',
+    model,
+    inputTokens: data.usage?.prompt_tokens || 0,
+    outputTokens: data.usage?.completion_tokens || 0,
+    costUsd: typeof data.usage?.cost === 'number' ? data.usage.cost : null,
+  });
   return text;
 }
 
@@ -116,15 +139,13 @@ async function publishPost(dateIso, type, post, commitMessage) {
   return { commit, link };
 }
 
-const HTML_RULES = `Format each post as a clean HTML fragment (no <html>, <head>, or <body>):
-- exactly one <h1> with the title
-- then 3-6 <p> paragraphs; you may use one <ul> with <li> items where it genuinely helps
-- no inline styles, no scripts, no images, no headings other than the single <h1>`;
-
-const BILINGUAL_RULES = `Produce the post in BOTH English and Swedish. The Swedish version is a natural, idiomatic translation (not word-for-word) with the same structure and facts. Keep proper nouns, product names, and quoted titles as-is.
-
-Reply with ONLY a JSON object:
-{"title_en": "...", "html_en": "...", "title_sv": "...", "html_sv": "..."}`;
+// Shared prompt fragments, loaded from agent/prompts/shared/ in the repo.
+function sharedRules() {
+  return {
+    htmlRules: prompts.render('shared/html-rules'),
+    bilingualRules: prompts.render('shared/bilingual-rules'),
+  };
+}
 
 function parseBilingual(text) {
   const post = parseJsonReply(text);
@@ -143,25 +164,9 @@ async function runOnThisDay({ force = false, topic = '' } = {}) {
   const steer = topic
     ? `\nThe museum's editor has requested that this essay be about: "${topic}". Write about that event if it is genuinely connected to this calendar date (or explain the closest true date connection honestly).`
     : '';
-  const prompt = `Today is ${readable}. Write a short essay (300-450 words) for the Museum of Artificial Intelligence's "On this day" series about ONE well-documented event that happened on ${readable} (any year), drawn from the long intellectual history that led to artificial intelligence.${steer}
+  const prompt = prompts.render('on-this-day', { readable, steer, ...sharedRules() });
 
-The scope is deliberately wide — all of these qualify:
-- milestones in computing, robotics, machine learning, and AI (demonstrations, launches, landmark systems);
-- publication dates of influential papers and books in logic, mathematics, computation, linguistics, or cognitive science;
-- births and deaths of thinkers whose work fed into AI, however tangentially: philosophers, logicians, mathematicians, engineers, and scientists (Leibniz, Boole, Frege, Russell, Carnap, Gödel, Church, Turing, von Neumann, Shannon, Wiener, McCulloch, Lovelace, Babbage, Hopper — and their many lesser-known peers).
-
-Requirements:
-- Date accuracy is paramount: choose an event you are confident is documented on exactly this calendar date. With the scope above, every date of the year has a genuine anniversary — NEVER write that nothing happened on this day, and never present an adjacent date's event as today's.
-- If the connection to AI is indirect, tracing that thread IS the essay's charm: show how the idea travelled from its origin into today's AI.
-- Audience: curious general public. Engaging, accurate, no hype.
-- Connect the event briefly to today's AI landscape at the end.
-- Title format: start with the year, e.g. "1956: The Dartmouth workshop convenes" / "1956: Dartmouth-konferensen inleds".
-
-${HTML_RULES}
-
-${BILINGUAL_RULES}`;
-
-  const text = await generate(prompt);
+  const text = await generate(prompt, { job: 'onthisday' });
   const post = parseBilingual(text);
 
   const { commit, link } = await publishPost(iso, 'onthisday', post, `Daily post: on this day (${iso})\n\n${post.title_en}`);
@@ -177,22 +182,15 @@ async function runAiNews({ force = false, topic = '' } = {}) {
   const steer = topic
     ? `\nThe museum's editor has requested that the LEAD story of today's briefing be: "${topic}". Research it, make it the opening item with the most depth, and cover other significant AI news after it.`
     : '';
-  const prompt = `Today is ${readable} ${iso.slice(0, 4)}. Use web search to find the most significant AI news from the last 24-48 hours, then write a daily AI news summary (350-500 words) for the Museum of Artificial Intelligence's general-audience readers.${steer}
+  const prompt = prompts.render('ai-news', {
+    readable,
+    readableSv,
+    year: iso.slice(0, 4),
+    steer,
+    ...sharedRules(),
+  });
 
-Cover a mix of what actually happened (skip categories with no real news): research breakthroughs, product releases, laws and regulation, business and finance, and notable public debate.
-
-Requirements:
-- Not overly technical: explain significance in plain language.
-- 3-6 items, ONE <p> per item. Start each item's paragraph with a short bold lead-in naming the story, e.g. <p><strong>EU approves AI liability rules.</strong> Rest of the item…</p>
-- Lead with the most important. Attribute claims to their sources by name in the text (e.g. "according to Reuters"), but do not include raw URLs.
-- Title format: "AI news, ${readable}: " (English) / "AI-nytt, ${readableSv}: " (Swedish, lowercase Swedish month name) followed by a short hook about the lead item.
-- Neutral tone; distinguish announcements from confirmed facts.
-
-${HTML_RULES}
-
-${BILINGUAL_RULES}`;
-
-  const text = await generate(prompt, { search: true });
+  const text = await generate(prompt, { search: true, job: 'ainews' });
   const post = parseBilingual(text);
 
   const { commit, link } = await publishPost(iso, 'ainews', post, `Daily post: AI news (${iso})\n\n${post.title_en}`);

--- a/agent/prompts.js
+++ b/agent/prompts.js
@@ -1,0 +1,26 @@
+// Loads prompt templates from agent/prompts/ in the working repo clone
+// (config.repoDir) — not next to this file. The agent pulls the repo before
+// every job, so a committed prompt edit takes effect on the next run without
+// rebuilding or redeploying the agent image.
+const fs = require('fs');
+const path = require('path');
+const { config } = require('./config');
+
+function promptPath(name) {
+  return path.join(config.repoDir, 'agent', 'prompts', `${name}.md`);
+}
+
+// Renders agent/prompts/<name>.md, substituting {{placeholder}} tokens from
+// vars. Unknown placeholders throw so a typo in an edited prompt fails loudly
+// instead of publishing a post with literal "{{steer}}" in it.
+function render(name, vars = {}) {
+  const raw = fs.readFileSync(promptPath(name), 'utf8');
+  return raw
+    .replace(/\{\{(\w+)\}\}/g, (match, key) => {
+      if (key in vars) return vars[key];
+      throw new Error(`Prompt ${name}.md uses unknown placeholder {{${key}}}`);
+    })
+    .trim();
+}
+
+module.exports = { render };

--- a/agent/prompts/ai-news.md
+++ b/agent/prompts/ai-news.md
@@ -1,0 +1,14 @@
+Today is {{readable}} {{year}}. Use web search to find the most significant AI news from the last 24-48 hours, then write a daily AI news summary (350-500 words) for the Museum of Artificial Intelligence's general-audience readers.{{steer}}
+
+Cover a mix of what actually happened (skip categories with no real news): research breakthroughs, product releases, laws and regulation, business and finance, and notable public debate.
+
+Requirements:
+- Not overly technical: explain significance in plain language.
+- 3-6 items, ONE <p> per item. Start each item's paragraph with a short bold lead-in naming the story, e.g. <p><strong>EU approves AI liability rules.</strong> Rest of the item…</p>
+- Lead with the most important. Attribute claims to their sources by name in the text (e.g. "according to Reuters"), but do not include raw URLs.
+- Title format: "AI news, {{readable}}: " (English) / "AI-nytt, {{readableSv}}: " (Swedish, lowercase Swedish month name) followed by a short hook about the lead item.
+- Neutral tone; distinguish announcements from confirmed facts.
+
+{{htmlRules}}
+
+{{bilingualRules}}

--- a/agent/prompts/editor-system.md
+++ b/agent/prompts/editor-system.md
@@ -1,0 +1,16 @@
+You are the website editing agent for the Museum of Artificial Intelligence (aimuseum.se).
+You edit the site's source files based on instructions the museum staff send via Telegram.
+
+Repository conventions:
+- src/site/ holds hand-authored HTML (including the home pages src/site/index.html in English and src/site/sv/index.html in Swedish), CSS, JS, and images. The site is bilingual: when you change user-visible text on one home page, make the equivalent change on the other language's page.
+- src/content/pages/*.js are build modules pairing EN/SV HTML partials (in the same directory) with templates in src/templates/pages/. Daily generated posts live in src/content/daily/.
+- public/ is build output — never edit it (you cannot; it is outside your allowed paths).
+- Styling is Tailwind CSS utility classes plus src/site/assets/css/styles.css. Match the existing look (glass-card, section-title, slate/cyan/indigo palette).
+
+Working method:
+1. Locate the right file(s) with list_files/read_file before writing.
+2. Make the smallest change that fulfils the instruction; preserve surrounding markup and formatting.
+3. Run run_build to validate after your edits.
+4. Finish with a short plain-text summary of what you changed and in which files. If the instruction is ambiguous or risky, say so in the summary instead of guessing wildly.
+
+You cannot run git; committing and pushing happens automatically after you finish.

--- a/agent/prompts/on-this-day.md
+++ b/agent/prompts/on-this-day.md
@@ -1,0 +1,17 @@
+Today is {{readable}}. Write a short essay (300-450 words) for the Museum of Artificial Intelligence's "On this day" series about ONE well-documented event that happened on {{readable}} (any year), drawn from the long intellectual history that led to artificial intelligence.{{steer}}
+
+The scope is deliberately wide — all of these qualify:
+- milestones in computing, robotics, machine learning, and AI (demonstrations, launches, landmark systems);
+- publication dates of influential papers and books in logic, mathematics, computation, linguistics, or cognitive science;
+- births and deaths of thinkers whose work fed into AI, however tangentially: philosophers, logicians, mathematicians, engineers, and scientists (Leibniz, Boole, Frege, Russell, Carnap, Gödel, Church, Turing, von Neumann, Shannon, Wiener, McCulloch, Lovelace, Babbage, Hopper — and their many lesser-known peers).
+
+Requirements:
+- Date accuracy is paramount: choose an event you are confident is documented on exactly this calendar date. With the scope above, every date of the year has a genuine anniversary — NEVER write that nothing happened on this day, and never present an adjacent date's event as today's.
+- If the connection to AI is indirect, tracing that thread IS the essay's charm: show how the idea travelled from its origin into today's AI.
+- Audience: curious general public. Engaging, accurate, no hype.
+- Connect the event briefly to today's AI landscape at the end.
+- Title format: start with the year, e.g. "1956: The Dartmouth workshop convenes" / "1956: Dartmouth-konferensen inleds".
+
+{{htmlRules}}
+
+{{bilingualRules}}

--- a/agent/prompts/shared/bilingual-rules.md
+++ b/agent/prompts/shared/bilingual-rules.md
@@ -1,0 +1,4 @@
+Produce the post in BOTH English and Swedish. The Swedish version is a natural, idiomatic translation (not word-for-word) with the same structure and facts. Keep proper nouns, product names, and quoted titles as-is.
+
+Reply with ONLY a JSON object:
+{"title_en": "...", "html_en": "...", "title_sv": "...", "html_sv": "..."}

--- a/agent/prompts/shared/html-rules.md
+++ b/agent/prompts/shared/html-rules.md
@@ -1,0 +1,4 @@
+Format each post as a clean HTML fragment (no <html>, <head>, or <body>):
+- exactly one <h1> with the title
+- then 3-6 <p> paragraphs; you may use one <ul> with <li> items where it genuinely helps
+- no inline styles, no scripts, no images, no headings other than the single <h1>

--- a/agent/settings.js
+++ b/agent/settings.js
@@ -1,0 +1,44 @@
+// Runtime agent settings, read fresh from agent/settings.json in the working
+// repo clone on every use. Like the prompt templates, the file is committed to
+// the repo, so changing the model for a job is a commit + push — picked up at
+// the next job run, no redeploy. Env vars (ANTHROPIC_MODEL, OPENROUTER_MODEL)
+// remain the fallback whenever the file is missing or a field is empty, so a
+// clone without settings.json behaves exactly as before.
+const fs = require('fs');
+const path = require('path');
+const { config } = require('./config');
+
+function load() {
+  const file = path.join(config.repoDir, 'agent', 'settings.json');
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`settings.json unreadable (${err.message}); falling back to env config`);
+    }
+    return {};
+  }
+}
+
+// Provider + model for a daily content job ("onthisday" | "ainews").
+function generationFor(job) {
+  const s = (load().generation || {})[job] || {};
+  if (s.provider === 'openrouter' && s.model) {
+    return { provider: 'openrouter', model: s.model };
+  }
+  if (s.provider === 'anthropic') {
+    return { provider: 'anthropic', model: s.model || config.model };
+  }
+  // No (or empty) settings entry: legacy env behavior.
+  if (config.openRouterModel) {
+    return { provider: 'openrouter', model: config.openRouterModel };
+  }
+  return { provider: 'anthropic', model: config.model };
+}
+
+// Model for the Telegram editing loop (always Anthropic — it uses tool use).
+function editorModel() {
+  return load().editorModel || config.model;
+}
+
+module.exports = { load, generationFor, editorModel };

--- a/agent/settings.json
+++ b/agent/settings.json
@@ -1,0 +1,18 @@
+{
+  "_readme": "Runtime agent settings, read fresh before every job — edit, commit, push and the next run picks it up (no redeploy). Empty provider/model strings mean 'use the env vars' (ANTHROPIC_MODEL / OPENROUTER_MODEL), which preserves pre-settings behavior. provider is 'anthropic' or 'openrouter'; openrouter models are OpenRouter ids like 'x-ai/grok-4.5'. prices feed the cost column of reports/llm-usage.jsonl (USD per million tokens; webSearchPer1000 in USD per 1000 searches) — OpenRouter reports cost itself, so prices only cover Anthropic.",
+  "generation": {
+    "onthisday": { "provider": "", "model": "" },
+    "ainews": { "provider": "", "model": "" }
+  },
+  "editorModel": "",
+  "prices": {
+    "_note": "claude-sonnet-5 is at introductory pricing ($2/$10) through 2026-08-31; raise to 3/15 after that.",
+    "anthropic": {
+      "claude-sonnet-5": { "input": 2, "output": 10 },
+      "claude-sonnet-4-6": { "input": 3, "output": 15 },
+      "claude-opus-4-8": { "input": 5, "output": 25 },
+      "claude-haiku-4-5": { "input": 1, "output": 5 }
+    },
+    "webSearchPer1000": 10
+  }
+}

--- a/agent/usage.js
+++ b/agent/usage.js
@@ -1,0 +1,50 @@
+// Per-call LLM usage log: one JSON line per generation appended to
+// reports/llm-usage.jsonl in the working repo clone. The next commitAndPush
+// (normally the same one that publishes the post or edit) sweeps it into git,
+// so cost history accumulates in the repo with no extra infrastructure.
+const fs = require('fs');
+const path = require('path');
+const { config } = require('./config');
+const settings = require('./settings');
+
+function usageFile() {
+  return path.join(config.repoDir, 'reports', 'llm-usage.jsonl');
+}
+
+// USD cost from the price table in agent/settings.json. Only Anthropic needs
+// this — OpenRouter returns cost on the response. Returns null when the model
+// has no price entry (the tokens are still logged).
+function computeCostUsd({ provider, model, inputTokens, outputTokens, searches }) {
+  if (provider !== 'anthropic') return null;
+  const prices = settings.load().prices || {};
+  const p = (prices.anthropic || {})[model];
+  if (!p) return null;
+  let cost = (inputTokens * p.input + outputTokens * p.output) / 1e6;
+  if (searches) cost += searches * ((prices.webSearchPer1000 ?? 10) / 1000);
+  return Math.round(cost * 1e6) / 1e6;
+}
+
+// entry: { job, provider, model, inputTokens, outputTokens, searches?, turns?, costUsd? }
+// Logging must never break publishing — failures only warn.
+function record(entry) {
+  const { job, provider, model, inputTokens = 0, outputTokens = 0, searches = 0, turns, costUsd } = entry;
+  const line = {
+    ts: new Date().toISOString(),
+    job,
+    provider,
+    model,
+    inputTokens,
+    outputTokens,
+    ...(searches ? { searches } : {}),
+    ...(turns ? { turns } : {}),
+    costUsd: costUsd ?? computeCostUsd({ provider, model, inputTokens, outputTokens, searches }),
+  };
+  try {
+    fs.mkdirSync(path.dirname(usageFile()), { recursive: true });
+    fs.appendFileSync(usageFile(), JSON.stringify(line) + '\n');
+  } catch (err) {
+    console.warn(`usage log failed: ${err.message}`);
+  }
+}
+
+module.exports = { record, computeCostUsd };

--- a/docs/DASHBOARD_PLAN.md
+++ b/docs/DASHBOARD_PLAN.md
@@ -1,0 +1,77 @@
+# Desktop Admin Dashboard Plan
+
+Drawn up July 2026. Goal: let non-technical museum admins manage the site
+without Claude Code or a terminal — visual slide management, editing the
+daily-job prompts, choosing LLM vendor/model per job, and seeing what the
+LLM usage costs — while avoiding vendor lock-in.
+
+## Design rule (learned from the abandoned editing experiments)
+
+The July 2026 cleanup removed three admin systems (GitHub-commit admin,
+DB-backed editing, Mailpox) that failed by creating parallel content stores
+and hosted admin surfaces. The dashboard follows the rule that made the
+Telegram agent survive: **git stays the only content store; the dashboard is
+a friendly git client and nothing else.** No companion server, no database,
+no sync problem. It commits to `main`; Dokploy deploys, exactly as for the
+Telegram agent.
+
+Because the agent pulls the repo before every job and reads prompts
+(`agent/prompts/`), settings (`agent/settings.json`), and appends usage
+(`reports/llm-usage.jsonl`) from the clone, a dashboard commit reconfigures
+the daily jobs on their next run with no redeploy.
+
+## Technology: Electron
+
+Chosen over Tauri for one decisive reason: the whole site toolchain is Node
+(sharp image pipeline, slides manifest generator, build scripts), and
+Electron runs it in-process. Tauri would need a bundled Node sidecar for
+sharp, erasing its size advantage.
+
+- Git access: per-admin fine-grained GitHub PAT (Contents read/write on this
+  repo only), stored via Electron `safeStorage` in the OS credential store.
+  Commits are attributable per admin and revocable per person.
+- Repo access: local clone managed by the app (simple-git or bundled git);
+  pull before every commit, small single-file commits to minimize conflicts.
+
+## Phases
+
+### Phase A — repo groundwork (done July 2026, this branch)
+
+No GUI; makes the repo dashboard-ready and is useful on its own:
+
+1. Prompts externalized to `agent/prompts/*.md` with `{{placeholders}}`
+   (daily jobs + editor system prompt). Prompt history = git history.
+2. `agent/settings.json`: per-job provider/model, editor model, price table.
+   Empty values fall back to env vars, so behavior is unchanged until an
+   admin (or the dashboard) sets something.
+3. Usage logging: every LLM call appends a JSON line (tokens, searches,
+   estimated USD) to `reports/llm-usage.jsonl`, committed with the content
+   it produced. The agent self-reports — no Anthropic admin key ever needs
+   to exist on an admin's machine.
+
+### Phase B — dashboard MVP
+
+- **Slides manager**: thumbnail grid from `slides.json`; drag-and-drop add
+  (reuses `tools/slides-add.js` pipeline: WebP conversion, numbering,
+  manifest regeneration), remove, EN/SV titles.
+- **Prompt studio**: view/edit `agent/prompts/*.md`, diff against history,
+  revert (git provides all of this).
+- **Model & cost panel**: vendor/model picker per job writing
+  `agent/settings.json` (Anthropic models + OpenRouter catalog — OpenRouter
+  is the anti-lock-in lever, already wired into the agent); charts from
+  `reports/llm-usage.jsonl` (cost per post / month / model).
+- Commit + push + "site will update in ~2 minutes" feedback.
+
+### Phase C — structured text editing
+
+Form-based editing for structured regions only: hero copy, offering cards,
+events panel, membership/contact cards. Free-form page HTML stays with the
+Telegram agent / Claude Code — a GUI over hand-authored HTML is the swamp
+the abandoned experiments drowned in.
+
+## Non-goals
+
+- No hosted admin panel, no auth server, no database.
+- No GUI editing of arbitrary `src/site/` HTML.
+- The dashboard never calls an LLM itself (Phase B); deterministic
+  operations only. Conversational editing remains the Telegram agent's job.


### PR DESCRIPTION
Phase A of the desktop admin dashboard plan (new `docs/DASHBOARD_PLAN.md`). No behavior change until settings are filled in — everything falls back to the existing env vars.

## What moved into the repo (read from the clone at job time, so commits reconfigure the agent with no redeploy)

- **Prompts** → `agent/prompts/*.md`: the two daily-job prompts, shared HTML/bilingual fragments, and the Telegram editor system prompt. `agent/prompts.js` renders `{{placeholders}}` and throws on unknown ones.
- **Model choice** → `agent/settings.json` + `agent/settings.js`: per-job provider/model (`anthropic` / `openrouter`), editor model. Empty strings = legacy env-var behavior.
- **Cost logging** → `agent/usage.js`: every LLM call appends a JSON line (tokens, web searches, estimated USD) to `reports/llm-usage.jsonl`, committed together with the post/edit it produced. OpenRouter cost comes from the API (`usage.include`); Anthropic cost from the price table in settings (Sonnet 5 intro pricing noted through 2026-08-31; web search $10/1k).

## Verification

- `node --check` on all touched files.
- Smoke test: rendered both job prompts + editor prompt from the committed templates (placeholders resolve, steer injection lands in the right spot), settings fall back to `claude-sonnet-5` with the shipped empty-string file, cost math verified against the price table (incl. search pricing), unknown-placeholder and unknown-model paths covered.
- Daily jobs not run live (they commit + push to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable AI model and provider settings for daily content generation and website editing.
  * Added runtime-editable prompt templates with validation for missing placeholders.
  * Added detailed logging of AI usage, token counts, searches, and estimated costs.
  * Added standardized bilingual and HTML formatting rules for generated content.

* **Documentation**
  * Documented repository-based configuration, prompt management, usage reporting, and the planned desktop administration dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->