### PR TITLE
Dashboard MVP: Electron admin app for slides, prompts, models, and costs

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,51 @@
+# MAI Site Dashboard
+
+Desktop admin app for aimuseum.se — manage the home-page slideshow, the AI
+agent's prompts and model choices, and see LLM costs, without a terminal.
+Design and phases: `../docs/DASHBOARD_PLAN.md`.
+
+The dashboard is **a friendly git client**: every action edits files in your
+clone of the site repository, and the **Publish** button commits and pushes
+to `main`, which Dokploy deploys (site changes live in ~2 minutes; agent
+prompt/model changes apply from its next run — the agent pulls before every
+job).
+
+## Running (current dev form)
+
+```bash
+cd dashboard
+npm install
+npm start
+```
+
+Requirements on the machine:
+
+- Node.js + git installed, and a clone of this repository with push access
+  (the dashboard uses your normal git credentials).
+- The repo clone must have had `npm install` run at its root (the slide
+  pipeline uses the repo's own `sharp`).
+
+If the dashboard is started from inside the repo (this folder), it finds the
+repo automatically; otherwise use **Choose repo…** to point it at your clone.
+
+## What it does
+
+- **Slideshow** — thumbnail grid of the hero rotation. *Add photos…* runs
+  the same pipeline as `npm run slides:add` (WebP conversion, max 1920px,
+  numbering, manifest regeneration). *Remove* runs `slides-remove.js`.
+  EN/SV titles edit `slides.json`.
+- **Prompts** — edit the daily-job prompts and the Telegram editor's system
+  prompt (`agent/prompts/*.md`). `{{placeholders}}` must be kept.
+- **Models & costs** — per-job provider/model choice written to
+  `agent/settings.json` (Anthropic or OpenRouter — OpenRouter's catalog is
+  fetched live for autocomplete), plus cost tiles, a 30-day daily-cost
+  chart, and a per-model table from `reports/llm-usage.jsonl`.
+- **Publish** — pull → commit → push with your message. Until you publish,
+  changes are only in your local clone.
+
+## Not yet done (Phase B follow-ups)
+
+- Packaged installers (electron-builder) so admins don't need Node/npm.
+- Git-less operation for non-technical admins (bundled git or
+  isomorphic-git + a GitHub fine-grained PAT stored via `safeStorage`).
+- Conflict UX beyond pull-before-publish.

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -34,6 +34,11 @@ repo automatically; otherwise use **Choose repo…** to point it at your clone.
   the same pipeline as `npm run slides:add` (WebP conversion, max 1920px,
   numbering, manifest regeneration). *Remove* runs `slides-remove.js`.
   EN/SV titles edit `slides.json`.
+- **Notice** — the flash banner on both home pages ("Tonight's lecture is
+  fully booked"). On/off switch, EN/SV text, optional last-shown day with
+  quick-set buttons; expiry is checked in the visitor's browser
+  (`src/site/assets/js/notice.js` reading `/content/notice.json`), so a
+  dated notice disappears on its own without a rebuild.
 - **Prompts** — edit the daily-job prompts and the Telegram editor's system
   prompt (`agent/prompts/*.md`). `{{placeholders}}` must be kept.
 - **Models & costs** — per-job provider/model choice written to

--- a/dashboard/lib/dashlib.js
+++ b/dashboard/lib/dashlib.js
@@ -9,6 +9,7 @@ const WRITABLE_PREFIXES = [
   'agent/prompts/',
   'agent/settings.json',
   'src/site/images/slide/slides.json',
+  'src/site/content/notice.json',
 ];
 
 function safeAbs(repo, rel) {
@@ -81,6 +82,31 @@ function writeSettings(repo, settingsObj) {
   const text = JSON.stringify(settingsObj, null, 2) + '\n';
   JSON.parse(text);
   fs.writeFileSync(safeAbs(repo, SETTINGS_REL), text, 'utf8');
+}
+
+// ---------- Flash notice ----------
+
+const NOTICE_REL = 'src/site/content/notice.json';
+const EMPTY_NOTICE = { active: false, until: null, en: '', sv: '' };
+
+function readNotice(repo) {
+  const file = path.join(repo, NOTICE_REL);
+  if (!fs.existsSync(file)) return { ...EMPTY_NOTICE };
+  return { ...EMPTY_NOTICE, ...JSON.parse(fs.readFileSync(file, 'utf8')) };
+}
+
+function writeNotice(repo, notice) {
+  const clean = {
+    active: Boolean(notice.active),
+    until: notice.until ? String(notice.until) : null,
+    en: String(notice.en || ''),
+    sv: String(notice.sv || ''),
+  };
+  if (clean.until && !/^\d{4}-\d{2}-\d{2}$/.test(clean.until)) {
+    throw new Error(`"until" must be a YYYY-MM-DD date, got: ${clean.until}`);
+  }
+  fs.writeFileSync(safeAbs(repo, NOTICE_REL), JSON.stringify(clean, null, 2) + '\n', 'utf8');
+  return clean;
 }
 
 // ---------- Usage log ----------
@@ -164,6 +190,8 @@ module.exports = {
   writeRepoFile,
   readSettings,
   writeSettings,
+  readNotice,
+  writeNotice,
   readUsage,
   aggregateUsage,
   safeAbs,

--- a/dashboard/lib/dashlib.js
+++ b/dashboard/lib/dashlib.js
@@ -1,0 +1,170 @@
+// Pure filesystem helpers for the dashboard — everything takes the repo path
+// explicitly so the module is testable with plain node (no Electron).
+const fs = require('fs');
+const path = require('path');
+
+// Files the renderer is allowed to read/write, as repo-relative prefixes.
+// The dashboard is a content tool, not a code editor.
+const WRITABLE_PREFIXES = [
+  'agent/prompts/',
+  'agent/settings.json',
+  'src/site/images/slide/slides.json',
+];
+
+function safeAbs(repo, rel) {
+  const normalized = path.posix.normalize(String(rel).replace(/\\/g, '/'));
+  if (normalized.startsWith('..') || path.isAbsolute(normalized)) {
+    throw new Error(`Path outside repository: ${rel}`);
+  }
+  if (!WRITABLE_PREFIXES.some((p) => normalized === p || normalized.startsWith(p))) {
+    throw new Error(`Path not editable from the dashboard: ${rel}`);
+  }
+  return path.join(repo, normalized);
+}
+
+function looksLikeSiteRepo(dir) {
+  return fs.existsSync(path.join(dir, 'src', 'site', 'images', 'slide', 'slides.json'))
+    && fs.existsSync(path.join(dir, 'agent'));
+}
+
+// ---------- Slides ----------
+
+const SLIDES_REL = 'src/site/images/slide/slides.json';
+
+function listSlides(repo) {
+  const dir = path.join(repo, 'src', 'site', 'images', 'slide');
+  const manifest = JSON.parse(fs.readFileSync(path.join(dir, 'slides.json'), 'utf8'));
+  return manifest.map((s) => ({ ...s, absPath: path.join(dir, s.filename) }));
+}
+
+// entries: full manifest array as edited by the UI (absPath stripped).
+function saveSlidesManifest(repo, entries) {
+  const clean = entries.map(({ absPath, ...rest }) => rest);
+  fs.writeFileSync(safeAbs(repo, SLIDES_REL), JSON.stringify(clean, null, 2) + '\n', 'utf8');
+}
+
+// ---------- Prompts ----------
+
+function listPrompts(repo) {
+  const base = path.join(repo, 'agent', 'prompts');
+  const out = [];
+  (function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(abs);
+      else if (entry.name.endsWith('.md')) {
+        out.push('agent/prompts/' + path.relative(base, abs).replace(/\\/g, '/'));
+      }
+    }
+  })(base);
+  return out.sort();
+}
+
+function readRepoFile(repo, rel) {
+  return fs.readFileSync(safeAbs(repo, rel), 'utf8');
+}
+
+function writeRepoFile(repo, rel, content) {
+  fs.writeFileSync(safeAbs(repo, rel), content, 'utf8');
+}
+
+// ---------- Settings ----------
+
+const SETTINGS_REL = 'agent/settings.json';
+
+function readSettings(repo) {
+  return JSON.parse(fs.readFileSync(path.join(repo, SETTINGS_REL), 'utf8'));
+}
+
+function writeSettings(repo, settingsObj) {
+  // Round-trip through JSON to reject non-serializable input early.
+  const text = JSON.stringify(settingsObj, null, 2) + '\n';
+  JSON.parse(text);
+  fs.writeFileSync(safeAbs(repo, SETTINGS_REL), text, 'utf8');
+}
+
+// ---------- Usage log ----------
+
+function readUsage(repo) {
+  const file = path.join(repo, 'reports', 'llm-usage.jsonl');
+  if (!fs.existsSync(file)) return [];
+  return fs
+    .readFileSync(file, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+// Aggregates for the cost panel. days: [{date: 'YYYY-MM-DD', costUsd, calls}]
+// covering the last `windowDays` days (including zero days); byModel keyed on
+// "provider model"; monthCostUsd = current calendar month.
+function aggregateUsage(entries, { windowDays = 30, now = new Date() } = {}) {
+  const dayKey = (d) => d.toISOString().slice(0, 10);
+  const monthKey = now.toISOString().slice(0, 7);
+
+  const days = [];
+  const dayIndex = new Map();
+  for (let i = windowDays - 1; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * 86400000);
+    const key = dayKey(d);
+    dayIndex.set(key, days.length);
+    days.push({ date: key, costUsd: 0, calls: 0 });
+  }
+
+  const byModel = new Map();
+  let monthCostUsd = 0;
+  let windowCostUsd = 0;
+  let unpricedCalls = 0;
+
+  for (const e of entries) {
+    const cost = typeof e.costUsd === 'number' ? e.costUsd : 0;
+    if (typeof e.costUsd !== 'number') unpricedCalls++;
+    const ts = String(e.ts || '');
+    if (ts.slice(0, 7) === monthKey) monthCostUsd += cost;
+    const idx = dayIndex.get(ts.slice(0, 10));
+    if (idx !== undefined) {
+      days[idx].costUsd += cost;
+      days[idx].calls += 1;
+      windowCostUsd += cost;
+    }
+    const mk = `${e.provider || '?'} ${e.model || '?'}`;
+    const m = byModel.get(mk) || {
+      provider: e.provider, model: e.model, calls: 0, inputTokens: 0, outputTokens: 0, costUsd: 0,
+    };
+    m.calls += 1;
+    m.inputTokens += e.inputTokens || 0;
+    m.outputTokens += e.outputTokens || 0;
+    m.costUsd += cost;
+    byModel.set(mk, m);
+  }
+
+  return {
+    days,
+    byModel: [...byModel.values()].sort((a, b) => b.costUsd - a.costUsd),
+    monthCostUsd,
+    windowCostUsd,
+    totalCalls: entries.length,
+    unpricedCalls,
+  };
+}
+
+module.exports = {
+  looksLikeSiteRepo,
+  listSlides,
+  saveSlidesManifest,
+  listPrompts,
+  readRepoFile,
+  writeRepoFile,
+  readSettings,
+  writeSettings,
+  readUsage,
+  aggregateUsage,
+  safeAbs,
+};

--- a/dashboard/main.js
+++ b/dashboard/main.js
@@ -1,0 +1,214 @@
+// Electron main process: window + IPC. All repo work happens here (renderer is
+// sandboxed); the dashboard is a git client over the site repo — it edits
+// content files, runs the existing tools/slides-*.js pipeline, and publishes
+// by commit + push to main (Dokploy deploys from there).
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const { execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const simpleGit = require('simple-git');
+const lib = require('./lib/dashlib');
+
+let win;
+
+// ---------- Config (repo path) ----------
+
+function configFile() {
+  return path.join(app.getPath('userData'), 'config.json');
+}
+
+function loadConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(configFile(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function saveConfig(cfg) {
+  fs.mkdirSync(path.dirname(configFile()), { recursive: true });
+  fs.writeFileSync(configFile(), JSON.stringify(cfg, null, 2), 'utf8');
+}
+
+function repoPath() {
+  const cfg = loadConfig();
+  if (cfg.repoPath && lib.looksLikeSiteRepo(cfg.repoPath)) return cfg.repoPath;
+  // Dev default: the dashboard lives inside the site repo.
+  const parent = path.resolve(__dirname, '..');
+  if (lib.looksLikeSiteRepo(parent)) return parent;
+  return null;
+}
+
+// ---------- Helpers ----------
+
+function git() {
+  const repo = repoPath();
+  if (!repo) throw new Error('No site repository configured');
+  return simpleGit(repo);
+}
+
+// Run a repo tool (tools/slides-add.js etc.) with the Electron binary in
+// plain-Node mode, so it works the same in dev and when packaged.
+function runTool(script, args) {
+  const repo = repoPath();
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [path.join(repo, 'tools', script), ...args],
+      {
+        cwd: repo,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 5 * 60 * 1000,
+      },
+      (err, stdout = '', stderr = '') => {
+        resolve({ ok: !err, output: `${stdout}\n${stderr}`.trim() });
+      },
+    );
+  });
+}
+
+const ok = (data) => ({ ok: true, data });
+const fail = (err) => ({ ok: false, error: err.message || String(err) });
+
+function handle(channel, fn) {
+  ipcMain.handle(channel, async (event, ...args) => {
+    try {
+      return ok(await fn(...args));
+    } catch (err) {
+      return fail(err);
+    }
+  });
+}
+
+// ---------- IPC ----------
+
+handle('repo:info', async () => {
+  const repo = repoPath();
+  if (!repo) return { repo: null };
+  const status = await git().status();
+  const log = await git().log({ maxCount: 1 });
+  return {
+    repo,
+    branch: status.current,
+    dirty: status.files.map((f) => `${f.working_dir}${f.index} ${f.path}`.trim()),
+    behind: status.behind,
+    ahead: status.ahead,
+    lastCommit: log.latest ? `${log.latest.hash.slice(0, 7)} ${log.latest.message}` : '',
+  };
+});
+
+handle('repo:choose', async () => {
+  const res = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
+  if (res.canceled || !res.filePaths[0]) return null;
+  const chosen = res.filePaths[0];
+  if (!lib.looksLikeSiteRepo(chosen)) {
+    throw new Error('That folder does not look like the site repository (missing src/site or agent/).');
+  }
+  saveConfig({ ...loadConfig(), repoPath: chosen });
+  return chosen;
+});
+
+handle('repo:pull', async () => {
+  await git().pull('origin', undefined, { '--ff-only': null });
+  return true;
+});
+
+handle('repo:publish', async (message) => {
+  const g = git();
+  const before = await g.status();
+  if (before.files.length === 0 && before.ahead === 0) {
+    return { published: false, reason: 'No changes to publish.' };
+  }
+  // Pull first so the push is a fast-forward for the remote.
+  await g.fetch();
+  const status = await g.status();
+  if (status.behind > 0 && status.files.length > 0) {
+    await g.stash();
+    try {
+      await g.pull('origin', undefined, { '--ff-only': null });
+    } finally {
+      await g.stash(['pop']);
+    }
+  } else if (status.behind > 0) {
+    await g.pull('origin', undefined, { '--ff-only': null });
+  }
+  if ((await g.status()).files.length > 0) {
+    await g.add(['-A']);
+    await g.commit(message || 'Dashboard edit');
+  }
+  await g.push('origin');
+  const log = await g.log({ maxCount: 1 });
+  return { published: true, commit: `${log.latest.hash.slice(0, 7)} ${log.latest.message}` };
+});
+
+handle('slides:list', () => lib.listSlides(repoPath()));
+
+handle('slides:add', async () => {
+  const res = await dialog.showOpenDialog(win, {
+    title: 'Choose photos to add to the slideshow',
+    properties: ['openFile', 'multiSelections'],
+    filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'webp', 'avif', 'tif', 'tiff'] }],
+  });
+  if (res.canceled || res.filePaths.length === 0) return { added: false };
+  const result = await runTool('slides-add.js', res.filePaths);
+  if (!result.ok) throw new Error(result.output || 'slides-add failed');
+  return { added: true, output: result.output };
+});
+
+handle('slides:remove', async (filename) => {
+  const result = await runTool('slides-remove.js', [filename]);
+  if (!result.ok) throw new Error(result.output || 'slides-remove failed');
+  return result.output;
+});
+
+handle('slides:saveManifest', (entries) => {
+  lib.saveSlidesManifest(repoPath(), entries);
+  return true;
+});
+
+handle('prompts:list', () => lib.listPrompts(repoPath()));
+handle('prompts:read', (rel) => lib.readRepoFile(repoPath(), rel));
+handle('prompts:write', (rel, content) => {
+  lib.writeRepoFile(repoPath(), rel, content);
+  return true;
+});
+
+handle('settings:read', () => lib.readSettings(repoPath()));
+handle('settings:write', (settings) => {
+  lib.writeSettings(repoPath(), settings);
+  return true;
+});
+
+handle('usage:summary', () => lib.aggregateUsage(lib.readUsage(repoPath())));
+
+handle('openrouter:models', async () => {
+  const resp = await fetch('https://openrouter.ai/api/v1/models');
+  if (!resp.ok) throw new Error(`OpenRouter catalog: HTTP ${resp.status}`);
+  const data = await resp.json();
+  return (data.data || []).map((m) => m.id).sort();
+});
+
+// ---------- Window ----------
+
+function createWindow() {
+  win = new BrowserWindow({
+    width: 1280,
+    height: 860,
+    title: 'MAI Site Dashboard',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  win.removeMenu();
+  // Surface renderer errors in the terminal (npm start) for debuggability.
+  win.webContents.on('console-message', (event, level, message) => {
+    if (level >= 2) console.log(`[renderer] ${message}`);
+  });
+  win.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+}
+
+app.whenReady().then(createWindow);
+app.on('window-all-closed', () => app.quit());

--- a/dashboard/main.js
+++ b/dashboard/main.js
@@ -99,7 +99,11 @@ handle('repo:info', async () => {
 });
 
 handle('repo:choose', async () => {
-  const res = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
+  const res = await dialog.showOpenDialog(win, {
+    title: 'Choose the site folder (your copy of the website files)',
+    defaultPath: repoPath() || app.getPath('home'),
+    properties: ['openDirectory'],
+  });
   if (res.canceled || !res.filePaths[0]) return null;
   const chosen = res.filePaths[0];
   if (!lib.looksLikeSiteRepo(chosen)) {
@@ -173,6 +177,9 @@ handle('prompts:write', (rel, content) => {
   lib.writeRepoFile(repoPath(), rel, content);
   return true;
 });
+
+handle('notice:read', () => lib.readNotice(repoPath()));
+handle('notice:write', (notice) => lib.writeNotice(repoPath(), notice));
 
 handle('settings:read', () => lib.readSettings(repoPath()));
 handle('settings:write', (settings) => {

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,0 +1,919 @@
+{
+  "name": "mai-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mai-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "simple-git": "^3.27.0"
+      },
+      "devDependencies": {
+        "electron": "^33.2.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mai-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Desktop admin dashboard for aimuseum.se — slides, prompts, models, costs (docs/DASHBOARD_PLAN.md)",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "node test/dashlib.test.js"
+  },
+  "dependencies": {
+    "simple-git": "^3.27.0"
+  },
+  "devDependencies": {
+    "electron": "^33.2.0"
+  }
+}

--- a/dashboard/preload.js
+++ b/dashboard/preload.js
@@ -20,6 +20,8 @@ contextBridge.exposeInMainWorld('mai', {
   promptsList: () => invoke('prompts:list'),
   promptsRead: (rel) => invoke('prompts:read', rel),
   promptsWrite: (rel, content) => invoke('prompts:write', rel, content),
+  noticeRead: () => invoke('notice:read'),
+  noticeWrite: (n) => invoke('notice:write', n),
   settingsRead: () => invoke('settings:read'),
   settingsWrite: (s) => invoke('settings:write', s),
   usageSummary: () => invoke('usage:summary'),

--- a/dashboard/preload.js
+++ b/dashboard/preload.js
@@ -1,0 +1,27 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+// Every call returns { ok, data } or { ok: false, error } — the renderer
+// unwraps via api.call() so errors surface as exceptions with messages.
+async function invoke(channel, ...args) {
+  const res = await ipcRenderer.invoke(channel, ...args);
+  if (!res.ok) throw new Error(res.error);
+  return res.data;
+}
+
+contextBridge.exposeInMainWorld('mai', {
+  repoInfo: () => invoke('repo:info'),
+  repoChoose: () => invoke('repo:choose'),
+  repoPull: () => invoke('repo:pull'),
+  repoPublish: (message) => invoke('repo:publish', message),
+  slidesList: () => invoke('slides:list'),
+  slidesAdd: () => invoke('slides:add'),
+  slidesRemove: (filename) => invoke('slides:remove', filename),
+  slidesSaveManifest: (entries) => invoke('slides:saveManifest', entries),
+  promptsList: () => invoke('prompts:list'),
+  promptsRead: (rel) => invoke('prompts:read', rel),
+  promptsWrite: (rel, content) => invoke('prompts:write', rel, content),
+  settingsRead: () => invoke('settings:read'),
+  settingsWrite: (s) => invoke('settings:write', s),
+  usageSummary: () => invoke('usage:summary'),
+  openrouterModels: () => invoke('openrouter:models'),
+});

--- a/dashboard/renderer/app.js
+++ b/dashboard/renderer/app.js
@@ -157,6 +157,38 @@ async function openPrompt(rel) {
   }
 }
 
+// ---------- Flash notice ----------
+
+function todayIso(offsetDays = 0) {
+  const d = new Date(Date.now() + offsetDays * 86400000);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function noticeStatusLine() {
+  const active = $('#notice-active').checked;
+  const until = $('#notice-until').value;
+  const el = $('#notice-status');
+  if (!active) {
+    el.textContent = 'Hidden — visitors see nothing.';
+    el.classList.remove('on');
+  } else if (until && until < todayIso()) {
+    el.textContent = `Was visible until ${until} — now expired and hidden.`;
+    el.classList.remove('on');
+  } else {
+    el.textContent = until ? `Visible through ${until}.` : 'Visible until you switch it off.';
+    el.classList.add('on');
+  }
+}
+
+async function loadNotice() {
+  const n = await window.mai.noticeRead();
+  $('#notice-active').checked = n.active;
+  $('#notice-en').value = n.en || '';
+  $('#notice-sv').value = n.sv || '';
+  $('#notice-until').value = n.until || '';
+  noticeStatusLine();
+}
+
 // ---------- Models & costs ----------
 
 function modelRow(job) {
@@ -389,7 +421,7 @@ function showTab(name) {
 
 async function refreshAll() {
   await refreshRepo();
-  await Promise.all([loadSlides(), loadPrompts(), loadModels(), loadCosts()]);
+  await Promise.all([loadSlides(), loadNotice(), loadPrompts(), loadModels(), loadCosts()]);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -424,6 +456,32 @@ document.addEventListener('DOMContentLoaded', () => {
   $('#btn-save-titles').addEventListener('click', (e) => run(e.target, async () => {
     await window.mai.slidesSaveManifest(slides);
     toast('Titles saved. Publish to put them live.');
+    await refreshRepo();
+  }));
+
+  $('#notice-active').addEventListener('change', noticeStatusLine);
+  $('#notice-until').addEventListener('change', noticeStatusLine);
+  for (const b of document.querySelectorAll('.until-row button[data-days]')) {
+    b.addEventListener('click', () => {
+      $('#notice-until').value = todayIso(Number(b.dataset.days) - 1);
+      noticeStatusLine();
+    });
+  }
+  $('#notice-clear-until').addEventListener('click', () => {
+    $('#notice-until').value = '';
+    noticeStatusLine();
+  });
+
+  $('#btn-save-notice').addEventListener('click', (e) => run(e.target, async () => {
+    const active = $('#notice-active').checked;
+    const en = $('#notice-en').value.trim();
+    const sv = $('#notice-sv').value.trim();
+    if (active && !en && !sv) {
+      throw new Error('The notice is switched on but has no text — write something or switch it off.');
+    }
+    await window.mai.noticeWrite({ active, en, sv, until: $('#notice-until').value || null });
+    toast('Notice saved. Publish to put it live.');
+    noticeStatusLine();
     await refreshRepo();
   }));
 

--- a/dashboard/renderer/app.js
+++ b/dashboard/renderer/app.js
@@ -1,0 +1,444 @@
+/* Renderer logic. All disk/git work goes through window.mai (see preload.js). */
+const $ = (sel) => document.querySelector(sel);
+
+const ANTHROPIC_MODELS = ['claude-sonnet-5', 'claude-sonnet-4-6', 'claude-opus-4-8', 'claude-haiku-4-5'];
+const JOBS = [
+  { key: 'onthisday', label: '"On this day" essay', kind: 'generation' },
+  { key: 'ainews', label: 'AI news briefing', kind: 'generation' },
+  { key: 'editor', label: 'Telegram editor', kind: 'editor' },
+];
+
+let slides = [];
+let currentPrompt = null;
+let settingsDoc = null;
+
+// ---------- Toast ----------
+
+let toastTimer;
+function toast(msg, ms = 3500) {
+  const el = $('#toast');
+  el.textContent = msg;
+  el.hidden = false;
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => { el.hidden = true; }, ms);
+}
+
+async function run(btn, fn) {
+  const prev = btn && btn.textContent;
+  if (btn) { btn.disabled = true; btn.textContent = 'Working…'; }
+  try {
+    return await fn();
+  } catch (err) {
+    toast(err.message, 6000);
+    return null;
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = prev; }
+  }
+}
+
+// ---------- Repo header / publish bar ----------
+
+async function refreshRepo() {
+  try {
+    const info = await window.mai.repoInfo();
+    if (!info.repo) {
+      $('#repo-line').textContent = 'No site repository found — use "Choose repo…" to point at your clone.';
+      $('#publish-bar').hidden = true;
+      return;
+    }
+    $('#repo-line').textContent = `${info.repo} — branch ${info.branch}, last: ${info.lastCommit}`;
+    const pending = info.dirty.length + (info.ahead || 0);
+    $('#publish-bar').hidden = pending === 0;
+    $('#pending-summary').textContent = info.dirty.length
+      ? `${info.dirty.length} unpublished change${info.dirty.length === 1 ? '' : 's'}`
+      : `${info.ahead} committed change${info.ahead === 1 ? '' : 's'} not yet pushed`;
+  } catch (err) {
+    $('#repo-line').textContent = err.message;
+  }
+}
+
+// ---------- Slides ----------
+
+function fileUrl(absPath) {
+  return encodeURI('file:///' + absPath.replace(/\\/g, '/'));
+}
+
+async function loadSlides() {
+  slides = await window.mai.slidesList();
+  const grid = $('#slides-grid');
+  grid.textContent = '';
+  for (const s of slides) {
+    const card = document.createElement('div');
+    card.className = 'slide-card';
+
+    const img = document.createElement('img');
+    img.src = fileUrl(s.absPath);
+    img.alt = s.title || s.filename;
+    card.appendChild(img);
+
+    const body = document.createElement('div');
+    body.className = 'body';
+
+    const row = document.createElement('div');
+    row.className = 'row';
+    const name = document.createElement('span');
+    name.className = 'filename';
+    name.textContent = s.filename;
+    const del = document.createElement('button');
+    del.className = 'danger';
+    del.textContent = 'Remove';
+    del.addEventListener('click', () => removeSlide(del, s));
+    row.append(name, del);
+    body.appendChild(row);
+
+    for (const lang of ['en', 'sv']) {
+      const label = document.createElement('label');
+      label.textContent = lang === 'en' ? 'Title (English)' : 'Titel (svenska)';
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = (s.i18n && s.i18n[lang] && s.i18n[lang].title) || '';
+      input.addEventListener('input', () => {
+        s.i18n = s.i18n || {};
+        s.i18n[lang] = s.i18n[lang] || { title: '', description: '' };
+        s.i18n[lang].title = input.value;
+      });
+      label.appendChild(input);
+      body.appendChild(label);
+    }
+
+    card.appendChild(body);
+    grid.appendChild(card);
+  }
+}
+
+async function removeSlide(btn, s) {
+  if (!confirm(`Remove "${s.filename}" from the slideshow?\nThe image file is deleted (recoverable from git history until published… and from history after).`)) return;
+  await run(btn, async () => {
+    await window.mai.slidesRemove(s.filename);
+    toast(`Removed ${s.filename}`);
+    await loadSlides();
+    await refreshRepo();
+  });
+}
+
+// ---------- Prompts ----------
+
+const PROMPT_LABELS = {
+  'agent/prompts/on-this-day.md': '"On this day" essay',
+  'agent/prompts/ai-news.md': 'AI news briefing',
+  'agent/prompts/editor-system.md': 'Telegram editor (system)',
+  'agent/prompts/shared/html-rules.md': 'Shared: HTML rules',
+  'agent/prompts/shared/bilingual-rules.md': 'Shared: bilingual rules',
+};
+
+async function loadPrompts() {
+  const list = await window.mai.promptsList();
+  const aside = $('#prompt-list');
+  aside.textContent = '';
+  for (const rel of list) {
+    const btn = document.createElement('button');
+    btn.textContent = PROMPT_LABELS[rel] || rel.replace('agent/prompts/', '');
+    btn.dataset.rel = rel;
+    btn.addEventListener('click', () => openPrompt(rel));
+    aside.appendChild(btn);
+  }
+}
+
+async function openPrompt(rel) {
+  const content = await window.mai.promptsRead(rel);
+  currentPrompt = rel;
+  $('#prompt-name').textContent = PROMPT_LABELS[rel] || rel;
+  const editor = $('#prompt-editor');
+  editor.value = content;
+  editor.disabled = false;
+  $('#btn-save-prompt').disabled = false;
+  for (const b of document.querySelectorAll('#prompt-list button')) {
+    b.classList.toggle('active', b.dataset.rel === rel);
+  }
+}
+
+// ---------- Models & costs ----------
+
+function modelRow(job) {
+  const row = document.createElement('div');
+  row.className = 'model-row';
+  const label = document.createElement('span');
+  label.className = 'job';
+  label.textContent = job.label;
+
+  const providerSel = document.createElement('select');
+  providerSel.dataset.job = job.key;
+  if (job.kind === 'generation') {
+    for (const [value, text] of [['', 'Default (server setting)'], ['anthropic', 'Anthropic'], ['openrouter', 'OpenRouter']]) {
+      const opt = document.createElement('option');
+      opt.value = value;
+      opt.textContent = text;
+      providerSel.appendChild(opt);
+    }
+  } else {
+    const opt = document.createElement('option');
+    opt.value = 'anthropic';
+    opt.textContent = 'Anthropic (fixed)';
+    providerSel.appendChild(opt);
+    providerSel.disabled = true;
+  }
+
+  const modelInput = document.createElement('input');
+  modelInput.type = 'text';
+  modelInput.placeholder = 'model id (empty = default)';
+  modelInput.dataset.job = job.key;
+  modelInput.setAttribute('list', 'models-anthropic');
+  providerSel.addEventListener('change', () => {
+    modelInput.setAttribute('list', providerSel.value === 'openrouter' ? 'models-openrouter' : 'models-anthropic');
+  });
+
+  row.append(label, providerSel, modelInput);
+  return row;
+}
+
+async function loadModels() {
+  settingsDoc = await window.mai.settingsRead();
+  const rowsEl = $('#model-rows');
+  rowsEl.textContent = '';
+  for (const job of JOBS) rowsEl.appendChild(modelRow(job));
+
+  const gen = settingsDoc.generation || {};
+  for (const job of JOBS) {
+    const sel = document.querySelector(`select[data-job="${job.key}"]`);
+    const input = document.querySelector(`input[data-job="${job.key}"]`);
+    if (job.kind === 'generation') {
+      sel.value = (gen[job.key] && gen[job.key].provider) || '';
+      input.value = (gen[job.key] && gen[job.key].model) || '';
+      if (sel.value === 'openrouter') input.setAttribute('list', 'models-openrouter');
+    } else {
+      input.value = settingsDoc.editorModel || '';
+    }
+  }
+
+  const dlA = $('#models-anthropic');
+  dlA.textContent = '';
+  for (const m of ANTHROPIC_MODELS) {
+    const opt = document.createElement('option');
+    opt.value = m;
+    dlA.appendChild(opt);
+  }
+  // OpenRouter catalog is nice-to-have; ignore failures (offline etc.)
+  window.mai.openrouterModels().then((models) => {
+    const dl = $('#models-openrouter');
+    dl.textContent = '';
+    for (const m of models) {
+      const opt = document.createElement('option');
+      opt.value = m;
+      dl.appendChild(opt);
+    }
+  }).catch(() => {});
+}
+
+function collectSettings() {
+  const out = { ...settingsDoc };
+  out.generation = JSON.parse(JSON.stringify(settingsDoc.generation || {}));
+  for (const job of JOBS) {
+    const input = document.querySelector(`input[data-job="${job.key}"]`);
+    if (job.kind === 'generation') {
+      const sel = document.querySelector(`select[data-job="${job.key}"]`);
+      out.generation[job.key] = { provider: sel.value, model: input.value.trim() };
+    } else {
+      out.editorModel = input.value.trim();
+    }
+  }
+  return out;
+}
+
+// ---------- Cost panel ----------
+
+const usd = (n) => '$' + (Math.round(n * 100) / 100).toFixed(2);
+
+function renderTiles(sum) {
+  const tiles = [
+    { label: 'This month', value: usd(sum.monthCostUsd) },
+    { label: 'Last 30 days', value: usd(sum.windowCostUsd) },
+    { label: 'LLM calls logged', value: String(sum.totalCalls) },
+  ];
+  if (sum.unpricedCalls) {
+    tiles.push({ label: 'Calls without price data', value: String(sum.unpricedCalls) });
+  }
+  const el = $('#stat-tiles');
+  el.textContent = '';
+  for (const t of tiles) {
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    const v = document.createElement('div');
+    v.className = 'value';
+    v.textContent = t.value;
+    const l = document.createElement('div');
+    l.className = 'label';
+    l.textContent = t.label;
+    tile.append(v, l);
+    el.appendChild(tile);
+  }
+}
+
+function renderChart(days) {
+  const W = 820; const H = 200;
+  const pad = { top: 10, right: 8, bottom: 22, left: 44 };
+  const iw = W - pad.left - pad.right;
+  const ih = H - pad.top - pad.bottom;
+  const max = Math.max(0.01, ...days.map((d) => d.costUsd));
+  const barW = iw / days.length;
+
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${W} ${H}`);
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', 'Bar chart of daily LLM cost in US dollars over the last 30 days');
+
+  // gridlines + y labels (3 ticks)
+  for (let i = 0; i <= 3; i++) {
+    const val = (max / 3) * i;
+    const y = pad.top + ih - (ih * i) / 3;
+    const line = document.createElementNS(svgNS, 'line');
+    line.setAttribute('x1', pad.left); line.setAttribute('x2', W - pad.right);
+    line.setAttribute('y1', y); line.setAttribute('y2', y);
+    line.setAttribute('class', i === 0 ? 'baseline' : 'gridline');
+    svg.appendChild(line);
+    const label = document.createElementNS(svgNS, 'text');
+    label.setAttribute('x', pad.left - 6); label.setAttribute('y', y + 3);
+    label.setAttribute('text-anchor', 'end');
+    label.textContent = usd(val);
+    svg.appendChild(label);
+  }
+
+  const tooltip = $('#chart-tooltip');
+  days.forEach((d, i) => {
+    const h = Math.round((d.costUsd / max) * ih);
+    const x = pad.left + i * barW + barW * 0.15;
+    const y = pad.top + ih - h;
+    const rect = document.createElementNS(svgNS, 'rect');
+    rect.setAttribute('x', x);
+    rect.setAttribute('y', y);
+    rect.setAttribute('width', barW * 0.7);
+    rect.setAttribute('height', Math.max(h, d.costUsd > 0 ? 2 : 0));
+    rect.setAttribute('rx', Math.min(3, barW * 0.35));
+    rect.setAttribute('class', 'bar');
+    rect.addEventListener('mousemove', (ev) => {
+      tooltip.hidden = false;
+      tooltip.textContent = `${d.date} — ${usd(d.costUsd)} (${d.calls} call${d.calls === 1 ? '' : 's'})`;
+      tooltip.style.left = `${ev.clientX + 12}px`;
+      tooltip.style.top = `${ev.clientY - 28}px`;
+    });
+    rect.addEventListener('mouseleave', () => { tooltip.hidden = true; });
+    svg.appendChild(rect);
+
+    if (i % 5 === 0 || i === days.length - 1) {
+      const label = document.createElementNS(svgNS, 'text');
+      label.setAttribute('x', pad.left + i * barW + barW / 2);
+      label.setAttribute('y', H - 6);
+      label.setAttribute('text-anchor', 'middle');
+      label.textContent = d.date.slice(5);
+      svg.appendChild(label);
+    }
+  });
+
+  const holder = $('#cost-chart');
+  holder.textContent = '';
+  holder.appendChild(svg);
+}
+
+function renderModelTable(byModel) {
+  const tbody = $('#model-table tbody');
+  tbody.textContent = '';
+  for (const m of byModel) {
+    const tr = document.createElement('tr');
+    const cells = [
+      m.model || '?', m.provider || '?',
+      String(m.calls), m.inputTokens.toLocaleString(), m.outputTokens.toLocaleString(), usd(m.costUsd),
+    ];
+    cells.forEach((text, i) => {
+      const td = document.createElement('td');
+      if (i >= 2) td.className = 'num';
+      td.textContent = text;
+      tr.appendChild(td);
+    });
+    tbody.appendChild(tr);
+  }
+  if (byModel.length === 0) {
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 6;
+    td.className = 'muted';
+    td.textContent = 'No usage logged yet — data appears after the agent runs with the new logging.';
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  }
+}
+
+async function loadCosts() {
+  const sum = await window.mai.usageSummary();
+  renderTiles(sum);
+  renderChart(sum.days);
+  renderModelTable(sum.byModel);
+}
+
+// ---------- Tabs & wiring ----------
+
+function showTab(name) {
+  for (const b of document.querySelectorAll('.tab')) b.classList.toggle('active', b.dataset.tab === name);
+  for (const p of document.querySelectorAll('.tab-panel')) p.hidden = true;
+  $(`#tab-${name}`).hidden = false;
+}
+
+async function refreshAll() {
+  await refreshRepo();
+  await Promise.all([loadSlides(), loadPrompts(), loadModels(), loadCosts()]);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  for (const b of document.querySelectorAll('.tab')) {
+    b.addEventListener('click', () => showTab(b.dataset.tab));
+  }
+
+  $('#btn-refresh').addEventListener('click', (e) => run(e.target, refreshAll));
+
+  $('#btn-choose-repo').addEventListener('click', (e) => run(e.target, async () => {
+    const chosen = await window.mai.repoChoose();
+    if (chosen) await refreshAll();
+  }));
+
+  $('#btn-publish').addEventListener('click', (e) => run(e.target, async () => {
+    const msg = $('#publish-message').value.trim() || 'Dashboard edit';
+    const res = await window.mai.repoPublish(msg);
+    toast(res.published ? `Published: ${res.commit} — the site updates in a couple of minutes.` : res.reason);
+    $('#publish-message').value = '';
+    await refreshRepo();
+  }));
+
+  $('#btn-add-slides').addEventListener('click', (e) => run(e.target, async () => {
+    const res = await window.mai.slidesAdd();
+    if (res.added) {
+      toast('Photos added and converted. Review titles, then Publish.');
+      await loadSlides();
+      await refreshRepo();
+    }
+  }));
+
+  $('#btn-save-titles').addEventListener('click', (e) => run(e.target, async () => {
+    await window.mai.slidesSaveManifest(slides);
+    toast('Titles saved. Publish to put them live.');
+    await refreshRepo();
+  }));
+
+  $('#btn-save-prompt').addEventListener('click', (e) => run(e.target, async () => {
+    if (!currentPrompt) return;
+    await window.mai.promptsWrite(currentPrompt, $('#prompt-editor').value);
+    toast('Prompt saved. Publish to put it live — it applies from the next run.');
+    await refreshRepo();
+  }));
+
+  $('#btn-save-settings').addEventListener('click', (e) => run(e.target, async () => {
+    await window.mai.settingsWrite(collectSettings());
+    toast('Model choices saved. Publish to put them live.');
+    await refreshRepo();
+  }));
+
+  refreshAll();
+});

--- a/dashboard/renderer/index.html
+++ b/dashboard/renderer/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' file:; style-src 'self'" />
+  <title>MAI Site Dashboard</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <div class="brand">
+      <h1>MAI Site Dashboard</h1>
+      <div id="repo-line" class="muted">Loading repository…</div>
+    </div>
+    <div class="header-actions">
+      <button id="btn-refresh" title="Re-read everything from disk">Refresh</button>
+      <button id="btn-choose-repo" title="Point the dashboard at your clone of the site repository">Choose repo…</button>
+    </div>
+  </header>
+
+  <div id="publish-bar" hidden>
+    <span id="pending-summary"></span>
+    <input id="publish-message" type="text" placeholder="Describe the change (commit message)" />
+    <button id="btn-publish" class="primary">Publish to site</button>
+  </div>
+
+  <nav id="tabs">
+    <button class="tab active" data-tab="slides">Slideshow</button>
+    <button class="tab" data-tab="prompts">Prompts</button>
+    <button class="tab" data-tab="models">Models &amp; costs</button>
+  </nav>
+
+  <main>
+    <section id="tab-slides" class="tab-panel">
+      <div class="toolbar">
+        <button id="btn-add-slides" class="primary">Add photos…</button>
+        <button id="btn-save-titles">Save titles</button>
+        <span class="muted">Photos are converted to WebP and numbered automatically. Remember to Publish when done.</span>
+      </div>
+      <div id="slides-grid" class="grid"></div>
+    </section>
+
+    <section id="tab-prompts" class="tab-panel" hidden>
+      <div class="split">
+        <aside id="prompt-list"></aside>
+        <div class="editor-pane">
+          <div class="toolbar">
+            <strong id="prompt-name">Select a prompt</strong>
+            <button id="btn-save-prompt" disabled>Save prompt</button>
+          </div>
+          <p class="muted">Pieces in double curly braces like <code>{{readable}}</code> are filled in automatically — keep them.</p>
+          <textarea id="prompt-editor" spellcheck="false" disabled></textarea>
+        </div>
+      </div>
+    </section>
+
+    <section id="tab-models" class="tab-panel" hidden>
+      <h2>Which AI writes what</h2>
+      <p class="muted">Empty means "use the server default". Changes apply from the next morning run after you publish.</p>
+      <div id="model-rows"></div>
+      <div class="toolbar"><button id="btn-save-settings">Save model choices</button></div>
+
+      <h2>Costs</h2>
+      <div id="stat-tiles" class="tiles"></div>
+      <div class="viz-root">
+        <h3>Daily cost, last 30 days (USD)</h3>
+        <div id="cost-chart"></div>
+      </div>
+      <h3>By model (all time)</h3>
+      <table id="model-table">
+        <thead>
+          <tr><th>Model</th><th>Provider</th><th class="num">Calls</th><th class="num">Tokens in</th><th class="num">Tokens out</th><th class="num">Cost (USD)</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <datalist id="models-anthropic"></datalist>
+      <datalist id="models-openrouter"></datalist>
+    </section>
+  </main>
+
+  <div id="toast" hidden></div>
+  <div id="chart-tooltip" hidden></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/dashboard/renderer/index.html
+++ b/dashboard/renderer/index.html
@@ -14,7 +14,7 @@
     </div>
     <div class="header-actions">
       <button id="btn-refresh" title="Re-read everything from disk">Refresh</button>
-      <button id="btn-choose-repo" title="Point the dashboard at your clone of the site repository">Choose repo…</button>
+      <button id="btn-choose-repo" title="Only needed if the dashboard can't find the website files by itself">Site folder…</button>
     </div>
   </header>
 
@@ -26,6 +26,7 @@
 
   <nav id="tabs">
     <button class="tab active" data-tab="slides">Slideshow</button>
+    <button class="tab" data-tab="notice">Notice</button>
     <button class="tab" data-tab="prompts">Prompts</button>
     <button class="tab" data-tab="models">Models &amp; costs</button>
   </nav>
@@ -38,6 +39,39 @@
         <span class="muted">Photos are converted to WebP and numbered automatically. Remember to Publish when done.</span>
       </div>
       <div id="slides-grid" class="grid"></div>
+    </section>
+
+    <section id="tab-notice" class="tab-panel" hidden>
+      <h2>Flash notice on the home page</h2>
+      <p class="muted">A short banner at the top of both home pages — for things like "Tonight's lecture is fully booked" or puffing a seminar. It only shows while it's switched on (and, if you set a last day, until that day ends).</p>
+      <div class="notice-form">
+        <label class="check-row">
+          <input type="checkbox" id="notice-active" />
+          <strong>Show the notice on the website</strong>
+        </label>
+        <span id="notice-status" class="muted"></span>
+        <label>Text (English)
+          <textarea id="notice-en" rows="3" placeholder="Tonight's lecture is fully booked."></textarea>
+        </label>
+        <label>Text (Swedish)
+          <textarea id="notice-sv" rows="3" placeholder="Kvällens föreläsning är fullbokad."></textarea>
+        </label>
+        <div class="until-row">
+          <label>Show until (last day, optional)
+            <input type="date" id="notice-until" />
+          </label>
+          <span class="muted">or quick-set:</span>
+          <button data-days="1">Today only</button>
+          <button data-days="3">3 days</button>
+          <button data-days="7">1 week</button>
+          <button data-days="14">2 weeks</button>
+          <button id="notice-clear-until">No end date</button>
+        </div>
+        <div class="toolbar">
+          <button id="btn-save-notice" class="primary">Save notice</button>
+          <span class="muted">Then press Publish — it's live a couple of minutes later.</span>
+        </div>
+      </div>
     </section>
 
     <section id="tab-prompts" class="tab-panel" hidden>

--- a/dashboard/renderer/styles.css
+++ b/dashboard/renderer/styles.css
@@ -83,6 +83,15 @@ main { padding: 16px 20px 40px; }
 .slide-card label { font-size: 11px; color: var(--text-secondary); display: flex; flex-direction: column; gap: 2px; }
 .slide-card .row { display: flex; justify-content: space-between; align-items: center; }
 
+/* Notice */
+.notice-form { display: flex; flex-direction: column; gap: 12px; max-width: 640px; }
+.notice-form label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--text-secondary); }
+.notice-form textarea { resize: vertical; }
+.check-row { flex-direction: row !important; align-items: center; gap: 8px !important; color: var(--text-primary) !important; }
+.until-row { display: flex; align-items: end; gap: 8px; flex-wrap: wrap; }
+#notice-status { font-weight: 600; }
+#notice-status.on { color: var(--good); }
+
 /* Prompts */
 .split { display: grid; grid-template-columns: 260px 1fr; gap: 16px; }
 #prompt-list { display: flex; flex-direction: column; gap: 4px; }

--- a/dashboard/renderer/styles.css
+++ b/dashboard/renderer/styles.css
@@ -1,0 +1,127 @@
+/* Palette roles (light) — dark values swap below. */
+:root {
+  color-scheme: light;
+  --page: #f9f9f7;
+  --surface-1: #fcfcfb;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --muted: #898781;
+  --grid: #e1e0d9;
+  --baseline: #c3c2b7;
+  --border: rgba(11, 11, 11, 0.10);
+  --series-1: #2a78d6;
+  --good: #0ca30c;
+  --critical: #d03b3b;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --page: #0d0d0d;
+    --surface-1: #1a1a19;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --muted: #898781;
+    --grid: #2c2c2a;
+    --baseline: #383835;
+    --border: rgba(255, 255, 255, 0.10);
+    --series-1: #3987e5;
+  }
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-size: 14px;
+  background: var(--page);
+  color: var(--text-primary);
+}
+h1 { font-size: 18px; margin: 0; }
+h2 { font-size: 16px; margin: 24px 0 8px; }
+h3 { font-size: 13px; font-weight: 600; color: var(--text-secondary); margin: 16px 0 8px; }
+.muted { color: var(--muted); font-size: 12px; }
+code { background: var(--surface-1); border: 1px solid var(--border); border-radius: 3px; padding: 0 3px; }
+
+header {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 20px; border-bottom: 1px solid var(--border); background: var(--surface-1);
+}
+.header-actions { display: flex; gap: 8px; }
+
+button {
+  font: inherit; padding: 6px 14px; border-radius: 6px; cursor: pointer;
+  border: 1px solid var(--border); background: var(--surface-1); color: var(--text-primary);
+}
+button:hover:not(:disabled) { border-color: var(--baseline); }
+button:disabled { opacity: 0.5; cursor: default; }
+button.primary { background: var(--series-1); border-color: var(--series-1); color: #fff; }
+button.danger { color: var(--critical); }
+
+#publish-bar {
+  display: flex; gap: 10px; align-items: center;
+  padding: 10px 20px; background: var(--surface-1); border-bottom: 1px solid var(--border);
+}
+#publish-bar input { flex: 1; }
+input[type="text"], textarea, select {
+  font: inherit; color: var(--text-primary); background: var(--page);
+  border: 1px solid var(--baseline); border-radius: 6px; padding: 6px 8px;
+}
+
+#tabs { display: flex; gap: 4px; padding: 10px 20px 0; }
+.tab { border: none; background: none; padding: 8px 14px; border-radius: 6px 6px 0 0; color: var(--text-secondary); }
+.tab.active { background: var(--surface-1); color: var(--text-primary); border: 1px solid var(--border); border-bottom-color: var(--surface-1); font-weight: 600; }
+
+main { padding: 16px 20px 40px; }
+.toolbar { display: flex; gap: 10px; align-items: center; margin: 8px 0 16px; flex-wrap: wrap; }
+
+/* Slides */
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 14px; }
+.slide-card { background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.slide-card img { width: 100%; height: 140px; object-fit: cover; display: block; background: var(--grid); }
+.slide-card .body { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 6px; }
+.slide-card .filename { font-size: 11px; color: var(--muted); word-break: break-all; }
+.slide-card label { font-size: 11px; color: var(--text-secondary); display: flex; flex-direction: column; gap: 2px; }
+.slide-card .row { display: flex; justify-content: space-between; align-items: center; }
+
+/* Prompts */
+.split { display: grid; grid-template-columns: 260px 1fr; gap: 16px; }
+#prompt-list { display: flex; flex-direction: column; gap: 4px; }
+#prompt-list button { text-align: left; font-size: 13px; }
+#prompt-list button.active { border-color: var(--series-1); font-weight: 600; }
+#prompt-editor { width: 100%; min-height: 420px; font-family: ui-monospace, Consolas, monospace; font-size: 13px; line-height: 1.45; resize: vertical; }
+.editor-pane { display: flex; flex-direction: column; }
+
+/* Models */
+.model-row { display: grid; grid-template-columns: 160px 170px 1fr; gap: 10px; align-items: center; margin-bottom: 10px; max-width: 720px; }
+.model-row .job { font-weight: 600; }
+
+/* Cost panel */
+.tiles { display: flex; gap: 12px; flex-wrap: wrap; margin: 8px 0 4px; }
+.tile { background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px; padding: 10px 16px; min-width: 150px; }
+.tile .value { font-size: 22px; font-weight: 600; }
+.tile .label { font-size: 12px; color: var(--text-secondary); }
+
+.viz-root { background: var(--surface-1); border: 1px solid var(--border); border-radius: 8px; padding: 8px 16px 12px; max-width: 860px; }
+#cost-chart svg { display: block; width: 100%; height: auto; }
+#cost-chart .gridline { stroke: var(--grid); stroke-width: 1; }
+#cost-chart .baseline { stroke: var(--baseline); stroke-width: 1; }
+#cost-chart .bar { fill: var(--series-1); }
+#cost-chart .bar:hover { opacity: 0.8; }
+#cost-chart text { fill: var(--muted); font-size: 10px; font-variant-numeric: tabular-nums; }
+
+table { border-collapse: collapse; margin-top: 4px; }
+th, td { text-align: left; padding: 5px 14px 5px 0; border-bottom: 1px solid var(--grid); font-size: 13px; }
+th { color: var(--text-secondary); font-weight: 600; }
+td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+#toast {
+  position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+  background: var(--text-primary); color: var(--page);
+  padding: 8px 18px; border-radius: 8px; font-size: 13px; max-width: 80%;
+}
+#chart-tooltip {
+  position: fixed; pointer-events: none; z-index: 10;
+  background: var(--surface-1); border: 1px solid var(--border); border-radius: 6px;
+  padding: 5px 9px; font-size: 12px; box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  font-variant-numeric: tabular-nums;
+}

--- a/dashboard/test/dashlib.test.js
+++ b/dashboard/test/dashlib.test.js
@@ -30,6 +30,21 @@ assert.throws(() => lib.safeAbs(REPO, 'agent/prompts/../../package.json'), /not 
 const settings = lib.readSettings(REPO);
 assert(settings.generation && settings.prices, 'settings.json missing sections');
 
+// Notice: read defaults, write validation (in a temp repo so the real file is untouched)
+const os = require('os');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-notice-'));
+fs.mkdirSync(path.join(tmp, 'src', 'site', 'content'), { recursive: true });
+const n0 = lib.readNotice(tmp);
+assert.strictEqual(n0.active, false, 'missing notice should read as inactive');
+lib.writeNotice(tmp, { active: true, en: 'Fully booked', sv: 'Fullbokat', until: '2026-07-20' });
+const n1 = lib.readNotice(tmp);
+assert.strictEqual(n1.active, true);
+assert.strictEqual(n1.sv, 'Fullbokat');
+assert.strictEqual(n1.until, '2026-07-20');
+assert.throws(() => lib.writeNotice(tmp, { active: true, en: 'x', until: 'next week' }), /YYYY-MM-DD/);
+const realNotice = lib.readNotice(REPO);
+assert.strictEqual(typeof realNotice.active, 'boolean', 'repo notice.json unreadable');
+
 // Usage aggregation on synthetic entries
 const now = new Date('2026-07-18T12:00:00Z');
 const entries = [

--- a/dashboard/test/dashlib.test.js
+++ b/dashboard/test/dashlib.test.js
@@ -1,0 +1,52 @@
+// Node-only test of the dashboard's repo helpers against the real repo.
+// Run from dashboard/:  npm test
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const lib = require('../lib/dashlib');
+
+const REPO = path.resolve(__dirname, '..', '..');
+assert(lib.looksLikeSiteRepo(REPO), 'parent repo not recognized');
+
+// Slides
+const slides = lib.listSlides(REPO);
+assert(slides.length > 0, 'no slides found');
+assert(slides[0].filename && slides[0].absPath, 'slide entry missing fields');
+assert(fs.existsSync(slides[0].absPath), 'slide image missing on disk');
+
+// Prompts
+const prompts = lib.listPrompts(REPO);
+assert(prompts.includes('agent/prompts/on-this-day.md'), 'on-this-day prompt not listed');
+assert(prompts.includes('agent/prompts/shared/html-rules.md'), 'shared prompt not listed');
+const text = lib.readRepoFile(REPO, 'agent/prompts/on-this-day.md');
+assert(text.includes('{{readable}}'), 'prompt content unexpected');
+
+// Path safety
+assert.throws(() => lib.readRepoFile(REPO, '../secrets.txt'), /outside repository/);
+assert.throws(() => lib.readRepoFile(REPO, 'server/server.js'), /not editable/);
+assert.throws(() => lib.safeAbs(REPO, 'agent/prompts/../../package.json'), /not editable/);
+
+// Settings round-trip shape (no write to the real file)
+const settings = lib.readSettings(REPO);
+assert(settings.generation && settings.prices, 'settings.json missing sections');
+
+// Usage aggregation on synthetic entries
+const now = new Date('2026-07-18T12:00:00Z');
+const entries = [
+  { ts: '2026-07-18T04:00:00Z', job: 'ainews', provider: 'anthropic', model: 'claude-sonnet-5', inputTokens: 1000, outputTokens: 2000, costUsd: 0.05 },
+  { ts: '2026-07-17T04:00:00Z', job: 'onthisday', provider: 'anthropic', model: 'claude-sonnet-5', inputTokens: 500, outputTokens: 1500, costUsd: 0.02 },
+  { ts: '2026-06-01T04:00:00Z', job: 'edit', provider: 'anthropic', model: 'claude-sonnet-5', inputTokens: 100, outputTokens: 100, costUsd: 0.01 },
+  { ts: '2026-07-18T05:00:00Z', job: 'ainews', provider: 'openrouter', model: 'x-ai/grok-4.5', inputTokens: 900, outputTokens: 1100 },
+];
+const sum = lib.aggregateUsage(entries, { windowDays: 30, now });
+assert.strictEqual(sum.days.length, 30, 'window length wrong');
+assert.strictEqual(sum.days[29].date, '2026-07-18', 'window not anchored to today');
+assert.strictEqual(sum.days[29].calls, 2, 'today call count wrong');
+assert.strictEqual(Math.round(sum.monthCostUsd * 100) / 100, 0.07, 'month cost wrong');
+assert.strictEqual(Math.round(sum.windowCostUsd * 100) / 100, 0.07, 'window cost wrong');
+assert.strictEqual(sum.totalCalls, 4);
+assert.strictEqual(sum.unpricedCalls, 1, 'unpriced call not counted');
+assert.strictEqual(sum.byModel[0].model, 'claude-sonnet-5', 'model sort wrong');
+assert.strictEqual(sum.byModel[0].calls, 3);
+
+console.log('DASHLIB_TESTS_OK');

--- a/docs/DASHBOARD_PLAN.md
+++ b/docs/DASHBOARD_PLAN.md
@@ -49,7 +49,11 @@ No GUI; makes the repo dashboard-ready and is useful on its own:
    it produced. The agent self-reports — no Anthropic admin key ever needs
    to exist on an admin's machine.
 
-### Phase B — dashboard MVP
+### Phase B — dashboard MVP (first cut July 2026: `dashboard/`)
+
+Implemented as an Electron app in `dashboard/` (see its README). Runs from
+source (`npm start`) against a local clone for now; packaged installers and
+git-less operation for non-technical admins are the remaining Phase B work.
 
 - **Slides manager**: thumbnail grid from `slides.json`; drag-and-drop add
   (reuses `tools/slides-add.js` pipeline: WebP conversion, numbering,

--- a/src/site/assets/css/home.css
+++ b/src/site/assets/css/home.css
@@ -503,3 +503,33 @@ summary:focus-visible {
     outline: 2px solid var(--brass);
     outline-offset: 3px;
 }
+
+/* ---------- Flash notice banner (content/notice.json via assets/js/notice.js) ---------- */
+.flash-notice { padding-top: 1.25rem; }
+.flash-notice-card {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    border: 1px solid var(--brass);
+    border-left: 4px solid var(--brass);
+    background: color-mix(in srgb, var(--brass) 10%, transparent);
+    padding: 0.85rem 1.2rem;
+    border-radius: 6px;
+}
+.flash-notice-label {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--brass);
+    white-space: nowrap;
+}
+.flash-notice-text {
+    margin: 0;
+    color: var(--ink);
+    font-size: 1rem;
+    line-height: 1.5;
+}
+@media (max-width: 640px) {
+    .flash-notice-card { flex-direction: column; gap: 0.35rem; }
+}

--- a/src/site/assets/js/notice.js
+++ b/src/site/assets/js/notice.js
@@ -1,0 +1,30 @@
+// Flash notice banner on the home pages. Content lives in
+// /content/notice.json (edited from the admin dashboard). The banner shows
+// only when the notice is active, non-empty, and not past its "until" date
+// (inclusive, checked in the visitor's local time) — so a dated notice
+// disappears on its own without a rebuild.
+(async () => {
+  try {
+    const resp = await fetch('/content/notice.json', { cache: 'no-store' });
+    if (!resp.ok) return;
+    const notice = await resp.json();
+    if (!notice.active) return;
+
+    if (notice.until) {
+      const now = new Date();
+      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+      if (today > notice.until) return;
+    }
+
+    const lang = (document.documentElement.lang || 'en').slice(0, 2);
+    const text = ((lang === 'sv' ? notice.sv : notice.en) || notice.en || notice.sv || '').trim();
+    if (!text) return;
+
+    const el = document.getElementById('flash-notice');
+    if (!el) return;
+    el.querySelector('.flash-notice-text').textContent = text;
+    el.hidden = false;
+  } catch {
+    /* no notice on any error — the banner is never load-bearing */
+  }
+})();

--- a/src/site/content/notice.json
+++ b/src/site/content/notice.json
@@ -1,0 +1,6 @@
+{
+  "active": false,
+  "until": null,
+  "en": "",
+  "sv": ""
+}

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -66,6 +66,16 @@
 
     <main id="main">
 
+        <!-- Flash notice (content from /content/notice.json, shown by assets/js/notice.js) -->
+        <section id="flash-notice" class="flash-notice" hidden aria-live="polite">
+            <div class="container mx-auto px-4">
+                <div class="flash-notice-card">
+                    <span class="flash-notice-label">Notice</span>
+                    <p class="flash-notice-text"></p>
+                </div>
+            </div>
+        </section>
+
         <!-- Hero -->
         <section class="pt-14 md:pt-20 pb-16 md:pb-24">
             <div class="container mx-auto px-4">
@@ -409,5 +419,6 @@
     </footer>
 
     <script src="assets/js/home.js" defer></script>
+    <script src="assets/js/notice.js" defer></script>
 </body>
 </html>

--- a/src/site/sv/index.html
+++ b/src/site/sv/index.html
@@ -66,6 +66,16 @@
 
     <main id="main">
 
+        <!-- Flash notice (content from /content/notice.json, shown by assets/js/notice.js) -->
+        <section id="flash-notice" class="flash-notice" hidden aria-live="polite">
+            <div class="container mx-auto px-4">
+                <div class="flash-notice-card">
+                    <span class="flash-notice-label">Meddelande</span>
+                    <p class="flash-notice-text"></p>
+                </div>
+            </div>
+        </section>
+
         <!-- Hero -->
         <section class="pt-14 md:pt-20 pb-16 md:pb-24">
             <div class="container mx-auto px-4">
@@ -409,5 +419,6 @@
     </footer>
 
     <script src="../assets/js/home.js" defer></script>
+    <script src="../assets/js/notice.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
Phase B first cut of `docs/DASHBOARD_PLAN.md` — a desktop app so non-technical admins can manage the site without Claude Code or a terminal. It is strictly a git client over this repo: no server, no database, publish = pull → commit → push to `main` (Dokploy deploys).

## Tabs

- **Slideshow** — thumbnail grid of the hero rotation; *Add photos…* reuses `tools/slides-add.js` (WebP conversion, numbering, manifest regeneration; spawned with `ELECTRON_RUN_AS_NODE`), *Remove* reuses `slides-remove.js`; EN/SV titles edit `slides.json`.
- **Prompts** — edit `agent/prompts/*.md` (the daily-job and Telegram-editor prompts from PR #15), with friendly labels and a keep-the-placeholders note.
- **Models & costs** — per-job provider/model picker writing `agent/settings.json` (Anthropic model list + live OpenRouter catalog autocomplete = the anti-lock-in lever); cost tiles, 30-day daily-cost chart, per-model table from `reports/llm-usage.jsonl`.

## Security shape

Sandboxed renderer (contextIsolation, CSP, no nodeIntegration); all fs/git/tool work behind IPC in the main process with a write-path allowlist (`agent/prompts/`, `agent/settings.json`, `slides.json`). Pure repo helpers in `lib/dashlib.js`.

## Verification

- `npm test` (node-only): slides/prompts listing against the real repo, path-traversal and allowlist rejection, usage aggregation math (window anchoring, month totals, unpriced-call counting, model sort).
- Launched the app twice on Windows: window opens, all initial loads succeed, zero renderer console errors (renderer errors are forwarded to the terminal).
- Not yet done (listed in dashboard/README.md): packaged installers, git-less operation with PAT for admins without git/Node, richer conflict UX.

Run it: `cd dashboard && npm install && npm start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)