### PR TITLE
Dashboard: managed clone + stored token; publish always targets main

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,0 +1,2 @@
+# Local dev/test scratch (mock backend harness for the renderer UI)
+renderer/__mockharness.html

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -4,13 +4,34 @@ Desktop admin app for aimuseum.se — manage the home-page slideshow, the AI
 agent's prompts and model choices, and see LLM costs, without a terminal.
 Design and phases: `../docs/DASHBOARD_PLAN.md`.
 
-The dashboard is **a friendly git client**: every action edits files in your
+The dashboard is **a friendly git client**: every action edits files in a
 clone of the site repository, and the **Publish** button commits and pushes
 to `main`, which Dokploy deploys (site changes live in ~2 minutes; agent
 prompt/model changes apply from its next run — the agent pulls before every
 job).
 
-## Running (current dev form)
+## Two connection modes
+
+- **Managed (recommended, for non-technical admins).** The dashboard keeps
+  its **own private clone** in the app's user-data folder and authenticates
+  with a stored GitHub access token — no terminal, no shared checkout. On
+  first launch it shows a **Connect** panel: enter the repository
+  (`owner/name`) and a fine-grained personal access token with **Contents:
+  read and write** on that repo. The token is encrypted at rest with the OS
+  keychain (Windows DPAPI) via Electron `safeStorage`, and is sent only as an
+  HTTP auth header — never written to `.git/config`, never shown again. All
+  git runs non-interactively (`GIT_TERMINAL_PROMPT=0`), so a bad/expired
+  token fails with a clear message instead of hanging on a hidden prompt.
+- **Local (developer).** "Use a local folder instead" points the dashboard
+  at an existing checkout and uses ambient git credentials. In this mode it
+  **only publishes when the checkout is on `main`** — if you've left it on a
+  feature branch it refuses (loudly) rather than pushing the wrong branch.
+
+Either way, **Publish always targets `main`**: it commits your edits, rebases
+onto the latest `origin/main` (so the agent's daily posts and other admins'
+changes are integrated), and pushes.
+
+## Running (dev)
 
 ```bash
 cd dashboard
@@ -18,15 +39,9 @@ npm install
 npm start
 ```
 
-Requirements on the machine:
-
-- Node.js + git installed, and a clone of this repository with push access
-  (the dashboard uses your normal git credentials).
-- The repo clone must have had `npm install` run at its root (the slide
-  pipeline uses the repo's own `sharp`).
-
-If the dashboard is started from inside the repo (this folder), it finds the
-repo automatically; otherwise use **Choose repo…** to point it at your clone.
+Requirements on the machine: Node.js + git installed. For managed mode the
+app clones the repo itself; for local mode, point at a checkout whose root
+has had `npm install` run (the slide pipeline uses the repo's own `sharp`).
 
 ## What it does
 
@@ -45,12 +60,12 @@ repo automatically; otherwise use **Choose repo…** to point it at your clone.
   `agent/settings.json` (Anthropic or OpenRouter — OpenRouter's catalog is
   fetched live for autocomplete), plus cost tiles, a 30-day daily-cost
   chart, and a per-model table from `reports/llm-usage.jsonl`.
-- **Publish** — pull → commit → push with your message. Until you publish,
-  changes are only in your local clone.
+- **Publish** — commit → rebase onto `origin/main` → push, with your message.
+  Until you publish, changes are only in the (managed or local) clone.
 
 ## Not yet done (Phase B follow-ups)
 
 - Packaged installers (electron-builder) so admins don't need Node/npm.
-- Git-less operation for non-technical admins (bundled git or
-  isomorphic-git + a GitHub fine-grained PAT stored via `safeStorage`).
-- Conflict UX beyond pull-before-publish.
+- Automatic token-expiry detection with a re-connect prompt.
+- Richer merge-conflict resolution (today a conflicting concurrent edit is
+  reported and left for a retry, not resolved in-app).

--- a/dashboard/lib/secrets.js
+++ b/dashboard/lib/secrets.js
@@ -1,0 +1,88 @@
+// Encrypted token storage. The GitHub token is written to disk only after
+// encryption via Electron's safeStorage (OS keychain / DPAPI), never in
+// plaintext. The backend (safeStorage + file path) is injected so the pure
+// logic is testable with a fake in plain node.
+const fs = require('fs');
+
+// backend: { encrypt(str)->Buffer, decrypt(Buffer)->str, isAvailable()->bool }
+// fileArg: absolute path to the encrypted token blob, or a function returning
+// it (deferred so it can depend on Electron's userData path, ready post-launch).
+function makeSecrets(backend, fileArg) {
+  // Resolve on each call: with Electron the path depends on userData, which is
+  // only valid after the app is ready (this factory runs at module load).
+  const filePath = () => (typeof fileArg === 'function' ? fileArg() : fileArg);
+  return {
+    available() {
+      try {
+        return backend.isAvailable();
+      } catch {
+        return false;
+      }
+    },
+
+    has() {
+      return fs.existsSync(filePath());
+    },
+
+    save(token) {
+      if (!token || typeof token !== 'string') throw new Error('Token must be a non-empty string');
+      if (!backend.isAvailable()) {
+        throw new Error('Secure storage is unavailable on this system, so the token cannot be saved safely.');
+      }
+      const enc = backend.encrypt(token.trim());
+      fs.writeFileSync(filePath(), enc);
+    },
+
+    // Returns the token string, or null if none stored / undecryptable.
+    load() {
+      const file = filePath();
+      if (!fs.existsSync(file)) return null;
+      try {
+        return backend.decrypt(fs.readFileSync(file));
+      } catch {
+        return null;
+      }
+    },
+
+    clear() {
+      try {
+        fs.unlinkSync(filePath());
+      } catch (err) {
+        if (err.code !== 'ENOENT') throw err;
+      }
+    },
+  };
+}
+
+// Normalize "owner/name" (also accepts a full github URL) or throw.
+function normalizeRepo(githubRepo) {
+  const repo = String(githubRepo || '').trim().replace(/^https?:\/\/github\.com\//i, '').replace(/\.git$/, '');
+  if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) {
+    throw new Error(`Repository must look like "owner/name", got: ${githubRepo}`);
+  }
+  return repo;
+}
+
+// Per-command git args that inject the token as an HTTP Authorization header,
+// so the managed clone authenticates without an interactive credential helper
+// and WITHOUT persisting the token in .git/config. GitHub accepts a PAT via
+// Basic auth with the x-access-token username.
+function authHeaderArgs(token) {
+  if (!token) throw new Error('No token available for authenticated git operation');
+  const b64 = Buffer.from(`x-access-token:${token}`).toString('base64');
+  return ['-c', `http.extraHeader=Authorization: Basic ${b64}`];
+}
+
+// Public remote URL (no token) — stored as the clone's origin and shown in UI.
+function publicRemoteUrl(githubRepo) {
+  return `https://github.com/${normalizeRepo(githubRepo)}.git`;
+}
+
+// Redact a token anywhere it might appear in an error string or command echo,
+// so a failure message never leaks the secret to the UI or logs.
+function redact(text, token) {
+  if (!text || !token) return text;
+  return String(text).split(token).join('***');
+}
+
+module.exports = { makeSecrets, normalizeRepo, authHeaderArgs, publicRemoteUrl, redact };

--- a/dashboard/main.js
+++ b/dashboard/main.js
@@ -2,16 +2,24 @@
 // sandboxed); the dashboard is a git client over the site repo — it edits
 // content files, runs the existing tools/slides-*.js pipeline, and publishes
 // by commit + push to main (Dokploy deploys from there).
-const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+//
+// Two modes (see docs/DASHBOARD_PLAN.md):
+//  - "managed" (recommended, for non-technical admins): the app owns a private
+//    clone in its userData dir and authenticates with a stored GitHub token —
+//    no terminal, no shared checkout, always publishes to main.
+//  - "local" (dev): point at an existing clone and use its ambient git creds.
+const { app, BrowserWindow, ipcMain, dialog, safeStorage } = require('electron');
 const { execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const simpleGit = require('simple-git');
 const lib = require('./lib/dashlib');
+const secretsLib = require('./lib/secrets');
 
+const MAIN_BRANCH = 'main';
 let win;
 
-// ---------- Config (repo path) ----------
+// ---------- Config + secrets ----------
 
 function configFile() {
   return path.join(app.getPath('userData'), 'config.json');
@@ -30,21 +38,68 @@ function saveConfig(cfg) {
   fs.writeFileSync(configFile(), JSON.stringify(cfg, null, 2), 'utf8');
 }
 
+function managedClonePath() {
+  return path.join(app.getPath('userData'), 'site-clone');
+}
+
+const secrets = secretsLib.makeSecrets(
+  {
+    isAvailable: () => safeStorage.isEncryptionAvailable(),
+    encrypt: (s) => safeStorage.encryptString(s),
+    decrypt: (buf) => safeStorage.decryptString(buf),
+  },
+  () => path.join(app.getPath('userData'), 'github-token.enc'),
+);
+
+// Resolve the active repo path for the configured mode. managed → the private
+// clone (once it exists); local → configured path or the dev default (the
+// dashboard living inside the site repo).
 function repoPath() {
   const cfg = loadConfig();
+  if (cfg.mode === 'managed') {
+    const clone = managedClonePath();
+    return lib.looksLikeSiteRepo(clone) ? clone : null;
+  }
   if (cfg.repoPath && lib.looksLikeSiteRepo(cfg.repoPath)) return cfg.repoPath;
-  // Dev default: the dashboard lives inside the site repo.
   const parent = path.resolve(__dirname, '..');
   if (lib.looksLikeSiteRepo(parent)) return parent;
   return null;
 }
 
+function isManaged() {
+  return loadConfig().mode === 'managed';
+}
+
 // ---------- Helpers ----------
 
-function git() {
-  const repo = repoPath();
+// Non-interactive git in `dir`: GIT_TERMINAL_PROMPT=0 makes a missing/expired
+// credential fail fast with an error instead of hanging the app on a hidden
+// prompt (the reported "everything freezes" symptom); GCM_INTERACTIVE=never
+// suppresses any Git Credential Manager popup.
+function git(dir) {
+  const repo = dir || repoPath();
   if (!repo) throw new Error('No site repository configured');
-  return simpleGit(repo);
+  return simpleGit(repo).env({
+    ...process.env,
+    GIT_TERMINAL_PROMPT: '0',
+    GCM_INTERACTIVE: 'never',
+  });
+}
+
+// Args that inject the stored token as an auth header for a remote git op in
+// managed mode. In local mode there's no token; git uses ambient credentials.
+function authArgs() {
+  if (!isManaged()) return [];
+  const token = secrets.load();
+  if (!token) throw new Error('Not connected — no GitHub token stored. Use Connect to set it up.');
+  return secretsLib.authHeaderArgs(token);
+}
+
+function scrub(err) {
+  const token = isManaged() ? secrets.load() : null;
+  const msg = secretsLib.redact(err && err.message ? err.message : String(err), token);
+  const e = new Error(msg);
+  return e;
 }
 
 // Run a repo tool (tools/slides-add.js etc.) with the Electron binary in
@@ -69,28 +124,88 @@ function runTool(script, args) {
 }
 
 const ok = (data) => ({ ok: true, data });
-const fail = (err) => ({ ok: false, error: err.message || String(err) });
 
 function handle(channel, fn) {
   ipcMain.handle(channel, async (event, ...args) => {
     try {
       return ok(await fn(...args));
     } catch (err) {
-      return fail(err);
+      return { ok: false, error: scrub(err).message };
     }
   });
 }
 
+const NONINTERACTIVE_ENV = () => ({ ...process.env, GIT_TERMINAL_PROMPT: '0', GCM_INTERACTIVE: 'never' });
+
 // ---------- IPC ----------
+
+// Connection / setup state for the header and the setup panel.
+handle('setup:status', () => {
+  const cfg = loadConfig();
+  const repo = repoPath();
+  return {
+    mode: cfg.mode === 'managed' ? 'managed' : 'local',
+    githubRepo: cfg.githubRepo || '',
+    connected: Boolean(repo),
+    hasToken: secrets.has(),
+    secureStorage: secrets.available(),
+    repoPath: repo,
+  };
+});
+
+// Managed mode: clone the repo into the app's private dir using the token,
+// verify it's the museum site, then store the token encrypted. The token is
+// used only as an auth header (never written to .git/config or shown back).
+handle('setup:connectManaged', async ({ githubRepo, token }) => {
+  if (!secrets.available()) {
+    throw new Error('This computer has no secure storage available, so the access token cannot be stored safely. Use "Site folder…" with a local copy instead.');
+  }
+  const repo = secretsLib.normalizeRepo(githubRepo);
+  const t = String(token || '').trim();
+  if (!t) throw new Error('Please paste your GitHub access token.');
+
+  const clone = managedClonePath();
+  fs.rmSync(clone, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(clone), { recursive: true });
+
+  // Clone with the token injected as a header; store the plain URL as origin.
+  await simpleGit(path.dirname(clone))
+    .env(NONINTERACTIVE_ENV())
+    .raw([...secretsLib.authHeaderArgs(t), 'clone', '--branch', MAIN_BRANCH, secretsLib.publicRemoteUrl(repo), clone]);
+
+  if (!lib.looksLikeSiteRepo(clone)) {
+    fs.rmSync(clone, { recursive: true, force: true });
+    throw new Error('That repository does not look like the museum website (missing src/site or agent/). Check the owner/name.');
+  }
+
+  const g = simpleGit(clone);
+  await g.addConfig('user.name', 'MAI Dashboard');
+  await g.addConfig('user.email', 'dashboard@aimuseum.se');
+
+  secrets.save(t);
+  saveConfig({ ...loadConfig(), mode: 'managed', githubRepo: repo });
+  return { connected: true, githubRepo: repo };
+});
+
+handle('setup:disconnect', () => {
+  secrets.clear();
+  fs.rmSync(managedClonePath(), { recursive: true, force: true });
+  saveConfig({ ...loadConfig(), mode: 'local' });
+  return true;
+});
 
 handle('repo:info', async () => {
   const repo = repoPath();
-  if (!repo) return { repo: null };
-  const status = await git().status();
-  const log = await git().log({ maxCount: 1 });
+  if (!repo) return { repo: null, mode: loadConfig().mode === 'managed' ? 'managed' : 'local' };
+  const g = git(repo);
+  const status = await g.status();
+  const log = await g.log({ maxCount: 1 });
   return {
     repo,
+    mode: isManaged() ? 'managed' : 'local',
+    githubRepo: loadConfig().githubRepo || '',
     branch: status.current,
+    onMainBranch: status.current === MAIN_BRANCH,
     dirty: status.files.map((f) => `${f.working_dir}${f.index} ${f.path}`.trim()),
     behind: status.behind,
     ahead: status.ahead,
@@ -98,6 +213,7 @@ handle('repo:info', async () => {
   };
 });
 
+// Local (dev) mode only: point at an existing checkout.
 handle('repo:choose', async () => {
   const res = await dialog.showOpenDialog(win, {
     title: 'Choose the site folder (your copy of the website files)',
@@ -109,39 +225,53 @@ handle('repo:choose', async () => {
   if (!lib.looksLikeSiteRepo(chosen)) {
     throw new Error('That folder does not look like the site repository (missing src/site or agent/).');
   }
-  saveConfig({ ...loadConfig(), repoPath: chosen });
+  saveConfig({ ...loadConfig(), mode: 'local', repoPath: chosen });
   return chosen;
 });
 
 handle('repo:pull', async () => {
-  await git().pull('origin', undefined, { '--ff-only': null });
+  await git().raw([...authArgs(), 'pull', '--ff-only', 'origin', MAIN_BRANCH]);
   return true;
 });
 
+// Publish = commit local edits, integrate remote main, push to main. Always
+// targets main so the deploy branch is what changes. Managed mode owns its
+// clone and keeps it on main; local mode refuses to publish off-main rather
+// than silently pushing a feature branch.
 handle('repo:publish', async (message) => {
-  const g = git();
-  const before = await g.status();
-  if (before.files.length === 0 && before.ahead === 0) {
+  const repo = repoPath();
+  if (!repo) throw new Error('No site repository configured.');
+  const g = git(repo);
+
+  const branch = (await g.revparse(['--abbrev-ref', 'HEAD'])).trim();
+  if (branch !== MAIN_BRANCH) {
+    if (isManaged()) {
+      await g.checkout(MAIN_BRANCH);
+    } else {
+      throw new Error(`The site folder is on branch "${branch}", but the dashboard publishes to "${MAIN_BRANCH}". Switch it to ${MAIN_BRANCH}, or use Connect to set up a managed copy.`);
+    }
+  }
+
+  const status = await g.status();
+  if (status.files.length === 0 && status.ahead === 0) {
     return { published: false, reason: 'No changes to publish.' };
   }
-  // Pull first so the push is a fast-forward for the remote.
-  await g.fetch();
-  const status = await g.status();
-  if (status.behind > 0 && status.files.length > 0) {
-    await g.stash();
-    try {
-      await g.pull('origin', undefined, { '--ff-only': null });
-    } finally {
-      await g.stash(['pop']);
-    }
-  } else if (status.behind > 0) {
-    await g.pull('origin', undefined, { '--ff-only': null });
-  }
-  if ((await g.status()).files.length > 0) {
+  if (status.files.length > 0) {
     await g.add(['-A']);
     await g.commit(message || 'Dashboard edit');
   }
-  await g.push('origin');
+
+  // Integrate anything new on origin/main (agent posts, other admins) before
+  // pushing. Rebase keeps history linear; on conflict, abort and report
+  // cleanly rather than leaving the clone mid-rebase.
+  try {
+    await g.raw([...authArgs(), 'pull', '--rebase', 'origin', MAIN_BRANCH]);
+  } catch (err) {
+    await g.raw(['rebase', '--abort']).catch(() => {});
+    throw new Error('Could not merge the latest site changes automatically — someone may have edited the same content. Nothing was published; please try again in a moment.');
+  }
+
+  await g.raw([...authArgs(), 'push', 'origin', `HEAD:${MAIN_BRANCH}`]);
   const log = await g.log({ maxCount: 1 });
   return { published: true, commit: `${log.latest.hash.slice(0, 7)} ${log.latest.message}` };
 });

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node test/dashlib.test.js"
+    "test": "node test/dashlib.test.js && node test/secrets.test.js"
   },
   "dependencies": {
     "simple-git": "^3.27.0"

--- a/dashboard/preload.js
+++ b/dashboard/preload.js
@@ -9,6 +9,9 @@ async function invoke(channel, ...args) {
 }
 
 contextBridge.exposeInMainWorld('mai', {
+  setupStatus: () => invoke('setup:status'),
+  connectManaged: (opts) => invoke('setup:connectManaged', opts),
+  disconnect: () => invoke('setup:disconnect'),
   repoInfo: () => invoke('repo:info'),
   repoChoose: () => invoke('repo:choose'),
   repoPull: () => invoke('repo:pull'),

--- a/dashboard/renderer/app.js
+++ b/dashboard/renderer/app.js
@@ -36,6 +36,41 @@ async function run(btn, fn) {
   }
 }
 
+// ---------- Connection / setup ----------
+
+let connected = false;
+
+async function refreshConnection() {
+  const s = await window.mai.setupStatus();
+  connected = s.connected;
+  const pill = $('#conn-state');
+  const managed = s.mode === 'managed';
+
+  if (connected) {
+    pill.textContent = managed ? `Connected: ${s.githubRepo}` : 'Local folder';
+    pill.className = 'conn-pill connected';
+  } else {
+    pill.textContent = 'Not connected';
+    pill.className = 'conn-pill disconnected';
+  }
+
+  // The overlay only blocks the app when there's no usable repo at all.
+  $('#setup-overlay').hidden = connected;
+  // Connect stays available in local/dev mode so a checkout can be upgraded to
+  // a managed connection; it's only hidden once managed-connected.
+  $('#btn-connect').hidden = managed && connected;
+  $('#btn-disconnect').hidden = !(managed && connected);
+  // The local-folder picker is a dev affordance reached from the setup panel
+  // ("Use a local folder instead"); keep it out of the header.
+  $('#btn-choose-repo').hidden = true;
+  return s;
+}
+
+function showSetup() {
+  $('#setup-overlay').hidden = false;
+  $('#setup-feedback').textContent = '';
+}
+
 // ---------- Repo header / publish bar ----------
 
 async function refreshRepo() {
@@ -420,6 +455,12 @@ function showTab(name) {
 }
 
 async function refreshAll() {
+  const status = await refreshConnection();
+  if (!status.connected) {
+    // Nothing to load until the dashboard is linked to the site.
+    $('#publish-bar').hidden = true;
+    return;
+  }
   await refreshRepo();
   await Promise.all([loadSlides(), loadNotice(), loadPrompts(), loadModels(), loadCosts()]);
 }
@@ -430,6 +471,35 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   $('#btn-refresh').addEventListener('click', (e) => run(e.target, refreshAll));
+
+  $('#btn-connect').addEventListener('click', showSetup);
+
+  $('#btn-do-connect').addEventListener('click', (e) => run(e.target, async () => {
+    const githubRepo = $('#setup-repo').value.trim();
+    const token = $('#setup-token').value;
+    if (!githubRepo || !token) {
+      $('#setup-feedback').textContent = 'Enter both the repository and the access code.';
+      return;
+    }
+    $('#setup-feedback').textContent = 'Connecting… (downloading the site, this can take a moment)';
+    await window.mai.connectManaged({ githubRepo, token });
+    $('#setup-token').value = '';
+    $('#setup-feedback').textContent = '';
+    toast('Connected. You can now edit and publish.');
+    await refreshAll();
+  }));
+
+  $('#btn-setup-local').addEventListener('click', (e) => run(e.target, async () => {
+    const chosen = await window.mai.repoChoose();
+    if (chosen) await refreshAll();
+  }));
+
+  $('#btn-disconnect').addEventListener('click', (e) => run(e.target, async () => {
+    if (!confirm('Disconnect this computer from the website? Your saved access code will be removed and the local copy deleted. You can reconnect anytime with the access code.')) return;
+    await window.mai.disconnect();
+    toast('Disconnected.');
+    await refreshAll();
+  }));
 
   $('#btn-choose-repo').addEventListener('click', (e) => run(e.target, async () => {
     const chosen = await window.mai.repoChoose();

--- a/dashboard/renderer/index.html
+++ b/dashboard/renderer/index.html
@@ -13,10 +13,33 @@
       <div id="repo-line" class="muted">Loading repository…</div>
     </div>
     <div class="header-actions">
+      <span id="conn-state" class="conn-pill"></span>
       <button id="btn-refresh" title="Re-read everything from disk">Refresh</button>
-      <button id="btn-choose-repo" title="Only needed if the dashboard can't find the website files by itself">Site folder…</button>
+      <button id="btn-connect" title="Connect the dashboard to the website with an access code">Connect…</button>
+      <button id="btn-disconnect" title="Disconnect this computer from the website" hidden>Disconnect</button>
+      <button id="btn-choose-repo" title="Developer option: point at a local checkout instead" hidden>Site folder…</button>
     </div>
   </header>
+
+  <!-- Connection setup (managed clone + access token). Shown until connected. -->
+  <div id="setup-overlay" hidden>
+    <div class="setup-card">
+      <h2>Connect the dashboard to the website</h2>
+      <p class="muted">This links the dashboard to the museum website so your changes can go live. You only do this once on this computer. You'll need a GitHub access code (a "fine-grained personal access token") with read &amp; write access to the site repository — ask whoever set up the site if you don't have one.</p>
+      <label>Website repository
+        <input id="setup-repo" type="text" placeholder="mindprints/MAI_DS_2" autocomplete="off" />
+      </label>
+      <label>Access code (token)
+        <input id="setup-token" type="password" placeholder="github_pat_…" autocomplete="off" />
+      </label>
+      <p class="muted">The access code is stored encrypted on this computer only, using Windows' built-in secure storage. It's never shown again and never leaves your machine except to talk to GitHub.</p>
+      <div class="toolbar">
+        <button id="btn-do-connect" class="primary">Connect</button>
+        <button id="btn-setup-local" title="Developer option">Use a local folder instead</button>
+        <span id="setup-feedback" class="muted"></span>
+      </div>
+    </div>
+  </div>
 
   <div id="publish-bar" hidden>
     <span id="pending-summary"></span>

--- a/dashboard/renderer/styles.css
+++ b/dashboard/renderer/styles.css
@@ -46,7 +46,25 @@ header {
   display: flex; justify-content: space-between; align-items: center;
   padding: 12px 20px; border-bottom: 1px solid var(--border); background: var(--surface-1);
 }
-.header-actions { display: flex; gap: 8px; }
+.header-actions { display: flex; gap: 8px; align-items: center; }
+.conn-pill { font-size: 12px; color: var(--muted); padding-right: 4px; }
+.conn-pill.connected { color: var(--good); }
+.conn-pill.disconnected { color: var(--critical); }
+
+/* Setup overlay */
+#setup-overlay {
+  position: fixed; inset: 0; z-index: 50;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex; align-items: center; justify-content: center; padding: 20px;
+}
+.setup-card {
+  background: var(--surface-1); border: 1px solid var(--border); border-radius: 12px;
+  padding: 24px 28px; max-width: 520px; width: 100%;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+}
+.setup-card h2 { margin-top: 0; }
+.setup-card label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--text-secondary); margin: 14px 0; }
+.setup-card input { width: 100%; }
 
 button {
   font: inherit; padding: 6px 14px; border-radius: 6px; cursor: pointer;

--- a/dashboard/test/secrets.test.js
+++ b/dashboard/test/secrets.test.js
@@ -1,0 +1,67 @@
+// Pure-logic tests for the token store and git auth helpers, using a fake
+// safeStorage backend (XOR "encryption" — enough to prove round-trip + that
+// what lands on disk isn't the plaintext token).
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { makeSecrets, normalizeRepo, authHeaderArgs, publicRemoteUrl, redact } = require('../lib/secrets');
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-secrets-'));
+const tokenFile = path.join(tmp, 'github-token.enc');
+
+let available = true;
+const fakeBackend = {
+  isAvailable: () => available,
+  encrypt: (s) => Buffer.from([...Buffer.from(s, 'utf8')].map((b) => b ^ 0x5a)),
+  decrypt: (buf) => Buffer.from([...buf].map((b) => b ^ 0x5a)).toString('utf8'),
+};
+
+const secrets = makeSecrets(fakeBackend, () => tokenFile);
+
+// Round-trip
+assert.strictEqual(secrets.has(), false, 'no token initially');
+assert.strictEqual(secrets.load(), null, 'load() null when absent');
+secrets.save('ghp_SECRETVALUE123');
+assert.strictEqual(secrets.has(), true, 'has() true after save');
+assert.strictEqual(secrets.load(), 'ghp_SECRETVALUE123', 'round-trips the token');
+
+// On-disk bytes must not contain the plaintext token
+const onDisk = fs.readFileSync(tokenFile);
+assert(!onDisk.includes(Buffer.from('ghp_SECRETVALUE123')), 'plaintext token must not be on disk');
+
+// clear
+secrets.clear();
+assert.strictEqual(secrets.has(), false, 'has() false after clear');
+assert.strictEqual(secrets.load(), null, 'load() null after clear');
+secrets.clear(); // idempotent, no throw
+
+// save refuses when secure storage unavailable
+available = false;
+assert.throws(() => secrets.save('x'), /unavailable/i, 'refuses to save without secure storage');
+available = true;
+
+// normalizeRepo
+assert.strictEqual(normalizeRepo('mindprints/MAI_DS_2'), 'mindprints/MAI_DS_2');
+assert.strictEqual(normalizeRepo('https://github.com/mindprints/MAI_DS_2.git'), 'mindprints/MAI_DS_2');
+assert.throws(() => normalizeRepo('not-a-repo'), /owner\/name/);
+assert.throws(() => normalizeRepo(''), /owner\/name/);
+
+// publicRemoteUrl carries no token
+assert.strictEqual(publicRemoteUrl('mindprints/MAI_DS_2'), 'https://github.com/mindprints/MAI_DS_2.git');
+
+// authHeaderArgs: -c http.extraHeader with base64(x-access-token:token), and
+// the raw token must not appear in the argument.
+const args = authHeaderArgs('ghp_ABC');
+assert.strictEqual(args[0], '-c');
+assert(args[1].startsWith('http.extraHeader=Authorization: Basic '), `unexpected header arg: ${args[1]}`);
+const b64 = args[1].split('Basic ')[1];
+assert.strictEqual(Buffer.from(b64, 'base64').toString('utf8'), 'x-access-token:ghp_ABC');
+assert(!args[1].includes('ghp_ABC'), 'raw token must not appear un-encoded in git args');
+assert.throws(() => authHeaderArgs(''), /No token/);
+
+// redact scrubs the token from error text
+assert.strictEqual(redact('fatal: bad creds ghp_ABC at end', 'ghp_ABC'), 'fatal: bad creds *** at end');
+assert.strictEqual(redact('no token here', null), 'no token here');
+
+console.log('SECRETS_TESTS_OK');

--- a/docs/DASHBOARD_PLAN.md
+++ b/docs/DASHBOARD_PLAN.md
@@ -52,8 +52,21 @@ No GUI; makes the repo dashboard-ready and is useful on its own:
 ### Phase B — dashboard MVP (first cut July 2026: `dashboard/`)
 
 Implemented as an Electron app in `dashboard/` (see its README). Runs from
-source (`npm start`) against a local clone for now; packaged installers and
-git-less operation for non-technical admins are the remaining Phase B work.
+source (`npm start`); packaged installers are the remaining Phase B work.
+
+**Connection (July 2026):** two modes. *Managed* — the app owns a private
+clone in its user-data folder and authenticates with a GitHub fine-grained
+token stored encrypted via `safeStorage` (OS keychain), injected only as an
+HTTP auth header and never persisted to `.git/config`; all git runs
+non-interactively so a bad token fails fast instead of hanging. This is the
+"access outside the CLI" path for non-technical admins — a first-run Connect
+panel takes a repo + token and clones. *Local* — a developer points at an
+existing checkout. Both modes publish only to `main` (managed keeps its clone
+on main; local refuses to publish off-main), committing then rebasing onto
+`origin/main` before pushing, so concurrent agent posts and other admins'
+edits are integrated. This replaced the original shared-dev-clone assumption,
+which made the dashboard see the developer's uncommitted files as "pending"
+and could push the wrong branch.
 
 - **Slides manager**: thumbnail grid from `slides.json`; drag-and-drop add
   (reuses `tools/slides-add.js` pipeline: WebP conversion, numbering,


### PR DESCRIPTION
Fixes the reported "dashboard isn't doing updates / commit field seems blocked," and delivers the outside-the-CLI admin access (your point #2) — they're the same fix.

## Diagnosis

The commit input and publish flow were never actually broken — I reproduced the renderer against a mock backend and typing, message pass-through, the success toast, and input-clear all worked. The real problem is architectural: the dashboard operated on the **developer's working checkout**. So it reported the developer's uncommitted files (e.g. a scratch file) as "1 unpublished change," and `git push` pushed whatever branch happened to be checked out — not `main`, which is what deploys. Hence "not updating," and a confusing/does-nothing feel. Credentials on this machine resolve fine (no literal hang here), but a GUI git subprocess elsewhere *could* hang on a hidden prompt — now prevented.

## Fix

- **Managed mode (recommended, non-technical admins):** the app owns a **private clone** in its user-data folder and authenticates with a stored GitHub fine-grained token. First-run **Connect** panel: repo (`owner/name`) + token → clone → verify it's the site. Token is encrypted at rest via `safeStorage` (Windows DPAPI), injected only as an HTTP auth header (never written to `.git/config`), and scrubbed from any error text.
- **Local mode (dev):** "Use a local folder instead" keeps the point-at-a-checkout behavior with ambient credentials.
- **Publish always targets `main`:** commit → rebase onto `origin/main` (integrates the agent's daily posts and other admins' edits) → push `HEAD:main`. Managed keeps its clone on main; local **refuses to publish off-main** instead of silently pushing a feature branch.
- **Non-interactive git** (`GIT_TERMINAL_PROMPT=0`, `GCM_INTERACTIVE=never`) so a bad/expired token fails fast with a clear message instead of freezing the UI.
- Renderer: connection pill, Connect/Disconnect, a setup overlay that gates editing until connected, token field cleared after connect.

## Verification

- `npm test`: existing dashlib tests + new `secrets.test.js` — token round-trip, **plaintext token never on disk**, refusal without secure storage, repo/URL/auth-header construction (token base64-encoded, never raw), token redaction in errors.
- Renderer connect → connected → disconnect driven in a mock backend: overlay gating, green/red connection pill, publish-bar activation, token field cleared.
- Real Electron app boots clean (no main/renderer errors).
- **Not testable here (needs a real PAT):** the live clone + push to GitHub. On-device steps are in `dashboard/README.md` → *Two connection modes*.

## Try it
`cd dashboard && npm install && npm start` → **Connect** → enter `mindprints/MAI_DS_2` + a fine-grained token with Contents: read/write → edit → Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)