### PR TITLE
Dashboard: fix "AllowUnsafeEditor" error on Connect

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -18,10 +18,16 @@ job).
   first launch it shows a **Connect** panel: enter the repository
   (`owner/name`) and a fine-grained personal access token with **Contents:
   read and write** on that repo. The token is encrypted at rest with the OS
-  keychain (Windows DPAPI) via Electron `safeStorage`, and is sent only as an
-  HTTP auth header — never written to `.git/config`, never shown again. All
-  git runs non-interactively (`GIT_TERMINAL_PROMPT=0`), so a bad/expired
-  token fails with a clear message instead of hanging on a hidden prompt.
+  keychain (Windows DPAPI) via Electron `safeStorage`. Reads (clone, pull)
+  use the public repository URL — no token, so they can't hang on
+  credentials; the token is used **only for push**, passed as a URL argument
+  so it is never written to `.git/config` and never shown again. Connect
+  does a no-op dry-run push to verify the token can write before saving it,
+  so a bad/expired or under-scoped token fails at Connect with a clear
+  message. Git runs non-interactively (`GIT_TERMINAL_PROMPT=0`,
+  `GCM_INTERACTIVE=never`, set on the app process — not via simple-git's
+  `.env()`, which would trip its unsafe-operations guard on a dev shell's
+  editor/ssh env vars).
 - **Local (developer).** "Use a local folder instead" points the dashboard
   at an existing checkout and uses ambient git credentials. In this mode it
   **only publishes when the checkout is on `main`** — if you've left it on a
@@ -66,6 +72,14 @@ has had `npm install` run (the slide pipeline uses the repo's own `sharp`).
 ## Not yet done (Phase B follow-ups)
 
 - Packaged installers (electron-builder) so admins don't need Node/npm.
+- **Add Photos in managed mode**: the managed clone has no `node_modules`, so
+  the `slides:add` image pipeline (which needs the repo's `sharp`) can't run
+  there yet — it needs the dashboard to bundle its own image tooling
+  (electron-rebuilt `sharp`). Everything else (notice, prompts, models,
+  removing slides, editing titles, publish) works in managed mode. In local
+  mode Add Photos uses the checkout's `sharp`.
+- Managed mode currently assumes the site repo is **public** for read (true
+  for aimuseum.se); a private repo would need the token on read too.
 - Automatic token-expiry detection with a re-connect prompt.
 - Richer merge-conflict resolution (today a conflicting concurrent edit is
   reported and left for a retry, not resolved in-app).

--- a/dashboard/lib/secrets.js
+++ b/dashboard/lib/secrets.js
@@ -63,14 +63,17 @@ function normalizeRepo(githubRepo) {
   return repo;
 }
 
-// Per-command git args that inject the token as an HTTP Authorization header,
-// so the managed clone authenticates without an interactive credential helper
-// and WITHOUT persisting the token in .git/config. GitHub accepts a PAT via
-// Basic auth with the x-access-token username.
-function authHeaderArgs(token) {
+// Authenticated remote URL, passed as a command ARGUMENT to clone/fetch/push
+// (never stored as origin), so git authenticates non-interactively without a
+// credential helper and the token is never written to .git/config. GitHub
+// accepts a PAT as the password with the x-access-token username.
+//
+// Passing the token this way (vs. simple-git's .env() or a `-c` config) avoids
+// simple-git's block-unsafe-operations guard, which scans any explicitly
+// passed env and refuses when it sees editor/ssh/pager vars a dev shell has.
+function authedRemoteUrl(githubRepo, token) {
   if (!token) throw new Error('No token available for authenticated git operation');
-  const b64 = Buffer.from(`x-access-token:${token}`).toString('base64');
-  return ['-c', `http.extraHeader=Authorization: Basic ${b64}`];
+  return `https://x-access-token:${encodeURIComponent(token)}@github.com/${normalizeRepo(githubRepo)}.git`;
 }
 
 // Public remote URL (no token) — stored as the clone's origin and shown in UI.
@@ -85,4 +88,4 @@ function redact(text, token) {
   return String(text).split(token).join('***');
 }
 
-module.exports = { makeSecrets, normalizeRepo, authHeaderArgs, publicRemoteUrl, redact };
+module.exports = { makeSecrets, normalizeRepo, authedRemoteUrl, publicRemoteUrl, redact };

--- a/dashboard/main.js
+++ b/dashboard/main.js
@@ -19,6 +19,14 @@ const secretsLib = require('./lib/secrets');
 const MAIN_BRANCH = 'main';
 let win;
 
+// Make every git subprocess non-interactive so a bad/expired token fails fast
+// instead of hanging on a hidden credential prompt. Set on THIS process (git
+// children inherit it) rather than via simple-git's .env() — passing an env to
+// simple-git triggers its block-unsafe-operations guard, which refuses when the
+// inherited env contains editor/ssh/pager vars a normal dev shell has.
+process.env.GIT_TERMINAL_PROMPT = '0';
+process.env.GCM_INTERACTIVE = 'never';
+
 // ---------- Config + secrets ----------
 
 function configFile() {
@@ -72,27 +80,23 @@ function isManaged() {
 
 // ---------- Helpers ----------
 
-// Non-interactive git in `dir`: GIT_TERMINAL_PROMPT=0 makes a missing/expired
-// credential fail fast with an error instead of hanging the app on a hidden
-// prompt (the reported "everything freezes" symptom); GCM_INTERACTIVE=never
-// suppresses any Git Credential Manager popup.
+// git client for `dir` (no .env() — see the process.env note above).
 function git(dir) {
   const repo = dir || repoPath();
   if (!repo) throw new Error('No site repository configured');
-  return simpleGit(repo).env({
-    ...process.env,
-    GIT_TERMINAL_PROMPT: '0',
-    GCM_INTERACTIVE: 'never',
-  });
+  return simpleGit(repo);
 }
 
-// Args that inject the stored token as an auth header for a remote git op in
-// managed mode. In local mode there's no token; git uses ambient credentials.
-function authArgs() {
-  if (!isManaged()) return [];
+// The remote for a PUSH: in managed mode, the token-bearing URL as an argument
+// (authenticates without persisting the token); in local mode, "origin" with
+// the user's ambient git credentials. Reads (clone/fetch/pull) use the public
+// "origin" — the museum site repo is public, so read needs no token and can
+// never hang on credentials.
+function pushRemote() {
+  if (!isManaged()) return 'origin';
   const token = secrets.load();
   if (!token) throw new Error('Not connected — no GitHub token stored. Use Connect to set it up.');
-  return secretsLib.authHeaderArgs(token);
+  return secretsLib.authedRemoteUrl(loadConfig().githubRepo, token);
 }
 
 function scrub(err) {
@@ -135,8 +139,6 @@ function handle(channel, fn) {
   });
 }
 
-const NONINTERACTIVE_ENV = () => ({ ...process.env, GIT_TERMINAL_PROMPT: '0', GCM_INTERACTIVE: 'never' });
-
 // ---------- IPC ----------
 
 // Connection / setup state for the header and the setup panel.
@@ -164,14 +166,22 @@ handle('setup:connectManaged', async ({ githubRepo, token }) => {
   const t = String(token || '').trim();
   if (!t) throw new Error('Please paste your GitHub access token.');
 
+  // Validate the token can push before we commit to managed mode: a dry-run
+  // push to a throwaway ref authenticates without changing anything. This turns
+  // a bad/expired token into a clear error at Connect time instead of at the
+  // first Publish.
+  const publicUrl = secretsLib.publicRemoteUrl(repo);
+  const authUrl = secretsLib.authedRemoteUrl(repo, t);
+
   const clone = managedClonePath();
   fs.rmSync(clone, { recursive: true, force: true });
   fs.mkdirSync(path.dirname(clone), { recursive: true });
 
-  // Clone with the token injected as a header; store the plain URL as origin.
+  // Clone via the PUBLIC url — the site repo is public, so read needs no token
+  // and can't hang on credentials. Origin stays public; only push carries the
+  // token (as a URL argument), so the token is never written to .git/config.
   await simpleGit(path.dirname(clone))
-    .env(NONINTERACTIVE_ENV())
-    .raw([...secretsLib.authHeaderArgs(t), 'clone', '--branch', MAIN_BRANCH, secretsLib.publicRemoteUrl(repo), clone]);
+    .raw(['clone', '--branch', MAIN_BRANCH, publicUrl, clone]);
 
   if (!lib.looksLikeSiteRepo(clone)) {
     fs.rmSync(clone, { recursive: true, force: true });
@@ -181,6 +191,15 @@ handle('setup:connectManaged', async ({ githubRepo, token }) => {
   const g = simpleGit(clone);
   await g.addConfig('user.name', 'MAI Dashboard');
   await g.addConfig('user.email', 'dashboard@aimuseum.se');
+
+  // Verify the token actually works for pushing (no-op dry run), so a bad token
+  // is caught now, not on first publish.
+  try {
+    await g.raw(['push', '--dry-run', authUrl, `${MAIN_BRANCH}:${MAIN_BRANCH}`]);
+  } catch (err) {
+    fs.rmSync(clone, { recursive: true, force: true });
+    throw new Error('Connected to the repository, but that access code could not push. Check the token has "Contents: read and write" permission on this repository and has not expired.');
+  }
 
   secrets.save(t);
   saveConfig({ ...loadConfig(), mode: 'managed', githubRepo: repo });
@@ -230,7 +249,7 @@ handle('repo:choose', async () => {
 });
 
 handle('repo:pull', async () => {
-  await git().raw([...authArgs(), 'pull', '--ff-only', 'origin', MAIN_BRANCH]);
+  await git().raw(['pull', '--ff-only', 'origin', MAIN_BRANCH]);
   return true;
 });
 
@@ -262,16 +281,16 @@ handle('repo:publish', async (message) => {
   }
 
   // Integrate anything new on origin/main (agent posts, other admins) before
-  // pushing. Rebase keeps history linear; on conflict, abort and report
-  // cleanly rather than leaving the clone mid-rebase.
+  // pushing — a public read, no token. Rebase keeps history linear; on
+  // conflict, abort and report cleanly rather than leaving a mid-rebase clone.
   try {
-    await g.raw([...authArgs(), 'pull', '--rebase', 'origin', MAIN_BRANCH]);
+    await g.raw(['pull', '--rebase', 'origin', MAIN_BRANCH]);
   } catch (err) {
     await g.raw(['rebase', '--abort']).catch(() => {});
     throw new Error('Could not merge the latest site changes automatically — someone may have edited the same content. Nothing was published; please try again in a moment.');
   }
 
-  await g.raw([...authArgs(), 'push', 'origin', `HEAD:${MAIN_BRANCH}`]);
+  await g.raw(['push', pushRemote(), `HEAD:${MAIN_BRANCH}`]);
   const log = await g.log({ maxCount: 1 });
   return { published: true, commit: `${log.latest.hash.slice(0, 7)} ${log.latest.message}` };
 });

--- a/dashboard/test/secrets.test.js
+++ b/dashboard/test/secrets.test.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { makeSecrets, normalizeRepo, authHeaderArgs, publicRemoteUrl, redact } = require('../lib/secrets');
+const { makeSecrets, normalizeRepo, authedRemoteUrl, publicRemoteUrl, redact } = require('../lib/secrets');
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-secrets-'));
 const tokenFile = path.join(tmp, 'github-token.enc');
@@ -50,15 +50,18 @@ assert.throws(() => normalizeRepo(''), /owner\/name/);
 // publicRemoteUrl carries no token
 assert.strictEqual(publicRemoteUrl('mindprints/MAI_DS_2'), 'https://github.com/mindprints/MAI_DS_2.git');
 
-// authHeaderArgs: -c http.extraHeader with base64(x-access-token:token), and
-// the raw token must not appear in the argument.
-const args = authHeaderArgs('ghp_ABC');
-assert.strictEqual(args[0], '-c');
-assert(args[1].startsWith('http.extraHeader=Authorization: Basic '), `unexpected header arg: ${args[1]}`);
-const b64 = args[1].split('Basic ')[1];
-assert.strictEqual(Buffer.from(b64, 'base64').toString('utf8'), 'x-access-token:ghp_ABC');
-assert(!args[1].includes('ghp_ABC'), 'raw token must not appear un-encoded in git args');
-assert.throws(() => authHeaderArgs(''), /No token/);
+// authedRemoteUrl: token embedded as x-access-token password, repo normalized,
+// token URL-encoded (so tokens with special chars are safe in the URL).
+assert.strictEqual(
+  authedRemoteUrl('mindprints/MAI_DS_2', 'ghp_ABC'),
+  'https://x-access-token:ghp_ABC@github.com/mindprints/MAI_DS_2.git',
+);
+assert.strictEqual(
+  authedRemoteUrl('https://github.com/mindprints/MAI_DS_2.git', 'ghp_ABC'),
+  'https://x-access-token:ghp_ABC@github.com/mindprints/MAI_DS_2.git',
+);
+assert(authedRemoteUrl('a/b', 'tok+/=en').includes(encodeURIComponent('tok+/=en')), 'token must be URL-encoded');
+assert.throws(() => authedRemoteUrl('a/b', ''), /No token/);
 
 // redact scrubs the token from error text
 assert.strictEqual(redact('fatal: bad creds ghp_ABC at end', 'ghp_ABC'), 'fatal: bad creds *** at end');


### PR DESCRIPTION
## The bug you hit

Connecting with a PAT failed with a message about needing to enable **AllowUnsafeEditor** — exact text `Use of "GIT_EDITOR" is not permitted without enabling allowUnsafeEditor`.

**Root cause:** to run git non-interactively I passed the whole `process.env` to `simple-git` via `.env()`. simple-git's `block-unsafe-operations` guard scans any env you explicitly hand it and refuses when it sees editor/ssh/pager vars — your dev shell has an editor var set. Nothing to do with your token.

("Use a local folder instead" only points at an existing checkout — it does **not** create a second clone, so no duplicate was made.)

## Fix

- Set `GIT_TERMINAL_PROMPT=0` / `GCM_INTERACTIVE=never` on the **app process** at startup (children inherit them) instead of via `simple-git` `.env()`, so the guard never scans an explicit env. Removed all `.env()` calls.
- **Auth redesign:** the site repo is public, so reads (clone, pull) use the public URL — no token, can't hang. The token is used **only for push**, as a URL argument (never written to `.git/config`).
- **Connect validates the token up front** via a no-op `push --dry-run`, so a bad/under-scoped token fails at Connect with a clear message.

## Verification

Reproduced the guard trip and confirmed removing `.env()` clears it; public read is fast and tokenless; dummy-token push fails fast (no hang/guard trip); dry-run push shape is guard-safe; confirmed `git config credential.helper` and `.env()` both trip the guard (avoided). `npm test` passes; app boots clean. Not verifiable in-sandbox: live clone+push timing (throttled net) and a real `github_pat_` PAT (only a GCM `gho_` token was available here).

## Known follow-up (README)

Add Photos doesn't work in managed mode yet (private clone has no `node_modules` for `sharp`); everything else works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed connections now verify GitHub write access before saving credentials.
  * Repository reads and cloning use the public repository URL, while credentials are used only when publishing changes.
  * Git operations now avoid interactive credential prompts.

* **Documentation**
  * Clarified managed connection behavior and credential handling.
  * Documented current limitations for private repositories and the `slides:add` pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->