### PR TITLE
Dashboard: fix setup overlay & publish bar not hiding

### DIFF
--- a/dashboard/renderer/styles.css
+++ b/dashboard/renderer/styles.css
@@ -52,7 +52,9 @@ header {
 .conn-pill.disconnected { color: var(--critical); }
 
 /* Setup overlay */
-#setup-overlay {
+/* :not([hidden]) so the `hidden` attribute actually hides it — an ID rule
+   setting `display` otherwise overrides the browser's [hidden]{display:none}. */
+#setup-overlay:not([hidden]) {
   position: fixed; inset: 0; z-index: 50;
   background: rgba(0, 0, 0, 0.55);
   display: flex; align-items: center; justify-content: center; padding: 20px;
@@ -75,7 +77,7 @@ button:disabled { opacity: 0.5; cursor: default; }
 button.primary { background: var(--series-1); border-color: var(--series-1); color: #fff; }
 button.danger { color: var(--critical); }
 
-#publish-bar {
+#publish-bar:not([hidden]) {
   display: flex; gap: 10px; align-items: center;
   padding: 10px 20px; background: var(--surface-1); border-bottom: 1px solid var(--border);
 }


### PR DESCRIPTION
## The bug

After a successful Connect, the setup card stayed on screen (couldn't be dismissed), and the publish bar showed "0 committed changes not yet pushed" when it should be hidden.

**Cause:** `#setup-overlay` and `#publish-bar` set `display: flex` on an ID selector, which outranks the browser's `[hidden] { display: none }`. The code toggled the `hidden` attribute correctly, but the `display: flex` always won, so they never visually hid. (This is also the "ghost overlay" I wrongly dismissed as a screenshot artifact in earlier testing.)

**Fix:** scope both rules with `:not([hidden])` so the `hidden` attribute takes effect.

**Verified in-browser:** with `hidden` set, computed `display` is now `none` (was `flex`); without it, `flex`.

## To recover

Close the stuck app window, `git pull`, `npm start`. You are already connected (token saved encrypted), so it reopens connected with the overlay correctly hidden — no need to re-enter the token.

Generated with Claude Code
