### PR TITLE
Serve clean URLs and a real 404 instead of the home page

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -25,8 +25,36 @@ app.use((req, res, next) => {
   next();
 });
 
-// Serve the built site from public/
-app.use(express.static(PUBLIC_DIR));
+// Resolve a request path to a file inside PUBLIC_DIR, or null if it escapes.
+function resolvePublic(urlPath, suffix = "") {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+  const rel = decoded.replace(/^\/+/, "").replace(/\/+$/, "");
+  if (!rel) return null;
+  const file = path.join(PUBLIC_DIR, rel + suffix);
+  if (file !== PUBLIC_DIR && !file.startsWith(PUBLIC_DIR + path.sep)) return null;
+  return file;
+}
+
+// Emulate Vercel's `cleanUrls` (see vercel.json): extensionless URLs map to
+// the matching .html file. Runs before express.static so that where both
+// pages/daily.html and pages/daily/ exist, the page wins over the directory.
+app.use((req, res, next) => {
+  if (req.method !== "GET" && req.method !== "HEAD") return next();
+  if (req.path.startsWith("/api/") || path.extname(req.path)) return next();
+  const file = resolvePublic(req.path, ".html");
+  if (file && fs.existsSync(file)) return res.sendFile(file);
+  next();
+});
+
+// Serve the built site from public/. `redirect: false` stops bare directory
+// URLs (/pages) from 301-ing to /pages/, where relative asset paths in the
+// fallback page would resolve one level too deep.
+app.use(express.static(PUBLIC_DIR, { redirect: false }));
 
 // Email sending endpoint (contact forms, workshop requests, membership)
 app.post("/api/send-email", handleSendEmail);
@@ -91,17 +119,34 @@ app.get("/api/og-image", async (req, res) => {
   }
 });
 
-// Fallback: serve index.html for unknown non-API paths
+// Fallback for paths nothing above matched.
 app.get("*", (req, res) => {
   if (req.path.startsWith("/api/")) {
     return res.status(404).json({ error: "Not found" });
   }
-  const indexPath = path.join(PUBLIC_DIR, "index.html");
-  if (fs.existsSync(indexPath)) {
-    res.sendFile(indexPath);
-  } else {
-    res.status(404).send("Page not found");
+
+  // A missing asset must 404. Answering a .css/.js request with index.html
+  // (200, text/html) is what made pages render unstyled.
+  if (path.extname(req.path)) {
+    return res.status(404).type("text/plain").send("Not found");
   }
+
+  // Directory that has its own index.html (/sv) — add the trailing slash so
+  // relative links inside it resolve correctly.
+  const dirIndex = resolvePublic(req.path, "/index.html");
+  if (dirIndex && fs.existsSync(dirIndex)) {
+    return res.redirect(301, req.path.replace(/\/+$/, "") + "/");
+  }
+
+  // Mistyped or listing-style URL (/pages): the 404 page, in the language of
+  // the branch that was missed. Its asset paths are absolute, so it renders
+  // correctly at whatever depth the visitor landed on.
+  const notFound = /^\/sv(\/|$)/.test(req.path) ? "sv/404.html" : "404.html";
+  const notFoundPath = path.join(PUBLIC_DIR, notFound);
+  if (fs.existsSync(notFoundPath)) {
+    return res.status(404).sendFile(notFoundPath);
+  }
+  res.status(404).type("text/plain").send("Page not found");
 });
 
 const PORT = process.env.PORT || 5179;

--- a/src/site/404.html
+++ b/src/site/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page not found — Museum of Artificial Intelligence</title>
+  <meta name="robots" content="noindex">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <!-- Absolute asset paths on purpose: this page is served at whatever URL
+       missed, so relative paths would resolve against the wrong directory. -->
+  <link rel="stylesheet" href="/assets/css/tailwind.css">
+  <link rel="stylesheet" href="/assets/css/styles.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg">
+  <link rel="icon" href="/favicon/favicon.ico" sizes="any">
+</head>
+<body>
+  <main class="min-h-screen flex items-center justify-center px-4 py-16">
+    <div class="w-full max-w-xl text-center">
+
+      <p class="heading-mono text-[0.62rem] tracking-[0.28em] uppercase text-[var(--ink-faint)]">Museum of Artificial Intelligence</p>
+      <p class="heading-mono text-6xl sm:text-7xl mt-6 text-[var(--brass)]">404</p>
+      <h1 class="text-3xl mt-4">This room isn't in the museum</h1>
+      <p class="mt-3 text-[var(--ink-dim)] leading-relaxed">The page you asked for doesn't exist — or it has been rehung somewhere else.</p>
+
+      <div class="glass-card p-6 mt-10 text-left">
+        <p class="heading-mono text-[0.62rem] tracking-[0.28em] uppercase mb-3 text-[var(--brass)]">While you're here</p>
+        <p class="text-[var(--ink-dim)] leading-relaxed">The word <em>robot</em> was coined in 1920 by a playwright, not an engineer. Karel Čapek used it in his play <em>R.U.R.</em>, borrowing the Czech <em>robota</em> — forced labour. His robots were artificial people, and the play ends with them replacing humanity altogether. We have been arguing about that ending ever since.</p>
+      </div>
+
+      <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
+        <a href="/" class="btn-brand text-[0.7rem] tracking-[0.18em] uppercase px-6 py-3 no-underline">Back to the entrance</a>
+        <a href="/sv/" class="cta-link heading-mono text-[0.7rem] tracking-[0.18em] uppercase px-6 py-3 no-underline text-[var(--ink-dim)]">Svenska</a>
+      </div>
+
+    </div>
+  </main>
+</body>
+</html>

--- a/src/site/sv/404.html
+++ b/src/site/sv/404.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sidan hittades inte — Museum of Artificial Intelligence</title>
+  <meta name="robots" content="noindex">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..600;1,9..144,300..600&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+  <!-- Absoluta sökvägar med flit: sidan serveras på den URL som missade,
+       så relativa sökvägar skulle peka fel katalog. -->
+  <link rel="stylesheet" href="/assets/css/tailwind.css">
+  <link rel="stylesheet" href="/assets/css/styles.css">
+  <link rel="icon" type="image/svg+xml" href="/favicon/favicon.svg">
+  <link rel="icon" href="/favicon/favicon.ico" sizes="any">
+</head>
+<body>
+  <main class="min-h-screen flex items-center justify-center px-4 py-16">
+    <div class="w-full max-w-xl text-center">
+
+      <p class="heading-mono text-[0.62rem] tracking-[0.28em] uppercase text-[var(--ink-faint)]">Museum of Artificial Intelligence</p>
+      <p class="heading-mono text-6xl sm:text-7xl mt-6 text-[var(--brass)]">404</p>
+      <h1 class="text-3xl mt-4">Den här salen finns inte i museet</h1>
+      <p class="mt-3 text-[var(--ink-dim)] leading-relaxed">Sidan du sökte finns inte — eller så har den hängts om någon annanstans.</p>
+
+      <div class="glass-card p-6 mt-10 text-left">
+        <p class="heading-mono text-[0.62rem] tracking-[0.28em] uppercase mb-3 text-[var(--brass)]">Kuriosa på vägen</p>
+        <p class="text-[var(--ink-dim)] leading-relaxed">Ordet <em>robot</em> myntades 1920 av en dramatiker, inte en ingenjör. Karel Čapek använde det i pjäsen <em>R.U.R.</em> och hämtade det från tjeckiskans <em>robota</em> — tvångsarbete. Hans robotar var konstgjorda människor, och pjäsen slutar med att de ersätter mänskligheten helt. Vi har grälat om det slutet sedan dess.</p>
+      </div>
+
+      <div class="mt-10 flex flex-wrap items-center justify-center gap-3">
+        <a href="/sv/" class="btn-brand text-[0.7rem] tracking-[0.18em] uppercase px-6 py-3 no-underline">Tillbaka till entrén</a>
+        <a href="/" class="cta-link heading-mono text-[0.7rem] tracking-[0.18em] uppercase px-6 py-3 no-underline text-[var(--ink-dim)]">English</a>
+      </div>
+
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Reported symptom: `aimuseum.se/pages` renders unstyled content.

## Cause

`vercel.json` sets `"cleanUrls": true`, and the site's markup relies on it — `public/pages/about.html` links to `../pages/about`. Since production moved off Vercel to the Express server, those extensionless URLs miss `express.static` and fall through to the `app.get("*")` handler, which returned `index.html` with status 200.

That is why the page was unstyled rather than merely wrong: `express.static` redirected `/pages` to `/pages/`, the fallback served `index.html` there, and its relative `assets/css/tailwind.css` resolved to `/pages/assets/css/tailwind.css` — which the same fallback answered with `index.html` as `text/html`, so the browser refused it as a stylesheet.

## Changes

- A cleanUrls middleware ahead of `express.static`, mapping extensionless paths to the matching `.html`. It runs first so that where both `pages/daily.html` and `pages/daily/` exist, the page wins over the directory redirect, matching Vercel's precedence.
- `redirect: false` on `express.static`, so a bare directory URL no longer 301s to a trailing slash that shifts relative asset paths one level too deep.
- Unmatched paths carrying a file extension now 404 instead of receiving `index.html`.
- 404 pages in English and Swedish, picked from the path, with absolute asset paths so they render at whatever depth the visitor landed on. They live in `src/site/` because `build:static` wipes and regenerates `public/`.

## Verified

Against a local run of the real server after a full `npm run build`:

| URL | before | after |
| --- | --- | --- |
| `/pages/about` | home page, unstyled (45 KB) | `about.html` (6 KB), styled |
| `/pages/daily` | 301 to directory, then home page | `daily.html` — file beats directory |
| `/pages/events/ai-in-medicine` | home page | real page |
| `/pages`, `/pages/`, `/nonexistent` | unstyled home page | 404 + English notice page |
| `/sv/pages`, `/sv/nope` | home page | 404 + Swedish page |
| `/sv` | home page | 301 to `/sv/` |
| `/pages/assets/css/tailwind.css` | 200 `text/html` | 404 |
| `/pages/../server/server.js` | — | 404, traversal blocked |

Computed styles on the 404 page at `/pages/deep/nope`: both stylesheets load from `/assets/css/`, body background `rgb(11, 12, 15)`, the numerals at 72px in brass `rgb(212, 160, 79)`, `.btn-brand` filled. Screenshots were unavailable in the session that produced this, so this is CSSOM evidence rather than an image.

## Note

Mistyped URLs now return 404 rather than the home page. There was no `404.html` before, which is why the fallback existed at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clean URL support for extensionless pages.
  * Added language-specific 404 pages in English and Swedish.
  * Directory-style URLs now redirect correctly when an index page is available.

* **Bug Fixes**
  * Unknown API routes now return a clear 404 response.
  * Invalid file and page requests no longer fall back to the homepage.
  * Improved protection against unsafe path access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->