### PR TITLE
Add /notice commands to the Telegram agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
 node_modules
+# Nested installs need their own pattern — a bare "node_modules" only matches
+# the top level, so dashboard/node_modules (Electron, a few hundred MB) was
+# being copied into both images.
+**/node_modules
 npm-debug.log
 .git
 .gitignore

--- a/agent/index.js
+++ b/agent/index.js
@@ -6,6 +6,7 @@ const telegram = require('./telegram');
 const gitrepo = require('./gitrepo');
 const { runEditInstruction } = require('./editor');
 const jobs = require('./jobs');
+const notice = require('./notice');
 const { startScheduler, nowInZone } = require('./scheduler');
 
 let busy = false;
@@ -41,6 +42,14 @@ Commands:
 /approve — merge the preview branch into main (if enabled)
 /help — this message
 
+Flash notice on the home pages (one at a time):
+/notice — show what is up right now
+/notice content <text> — set the text (English and Swedish)
+/notice sv <text> — correct the Swedish version
+/notice post — put it up; it stays until removed
+/notice remove — take it down
+Expiry dates stay in the dashboard; /notice post clears any date it finds.
+
 Edits are committed to ${config.agentBranch} and deploy to ${config.previewUrl || 'the site'}.`;
 
 async function handleEdit(msg, instruction) {
@@ -72,6 +81,66 @@ async function runJob(msg, name, fn, topic = '') {
   } else {
     await telegram.sendMessage(msg.chat.id, `Published: ${result.title}\n${result.link}`);
   }
+}
+
+const NOTICE_USAGE =
+  'Use: /notice · /notice content <text> · /notice sv <text> · /notice post · /notice remove';
+
+// The flash notice is a single file, so these subcommands edit one notice
+// rather than managing a list. Durations stay in the dashboard: /notice post
+// clears "until", so a posted notice runs until /notice remove takes it down.
+async function handleNotice(msg, arg) {
+  // Pull first — the dashboard writes this same file, and clobbering an edit
+  // made there would be silent.
+  await gitrepo.pull().catch(() => {});
+  const current = notice.read();
+
+  const sub = arg.split(/\s+/)[0] || '';
+  const body = arg.slice(sub.length).trim();
+
+  if (!sub) {
+    await telegram.sendMessage(msg.chat.id, notice.describe(current));
+    return;
+  }
+
+  let next;
+  let what;
+  if (sub === 'content' || sub === 'sv') {
+    if (!body) {
+      await telegram.sendMessage(msg.chat.id, `Send the text too, e.g. "/notice ${sub} Doors open at 18:00".`);
+      return;
+    }
+    next = sub === 'sv' ? { ...current, sv: body } : { ...current, en: body, sv: body };
+    what = sub === 'sv' ? 'Swedish text updated.' : 'Text set, in both languages.';
+    if (!current.active) what += ' Not posted yet — send /notice post when you want it up.';
+  } else if (sub === 'post') {
+    if (!current.en.trim() && !current.sv.trim()) {
+      await telegram.sendMessage(msg.chat.id, 'Nothing to post yet — set the text first with /notice content <text>.');
+      return;
+    }
+    next = { ...current, active: true, until: null };
+    what = notice.isExpired(current)
+      ? `Expiry date (${current.until}) cleared and the notice is back up.`
+      : 'Notice is up.';
+  } else if (sub === 'remove') {
+    if (!current.active) {
+      await telegram.sendMessage(msg.chat.id, `Nothing is posted right now.\n\n${notice.describe(current)}`);
+      return;
+    }
+    next = { ...current, active: false };
+    what = 'Notice taken down. The text is kept, so /notice post puts it back.';
+  } else {
+    await telegram.sendMessage(msg.chat.id, `Unknown notice command "${sub}".\n\n${NOTICE_USAGE}`);
+    return;
+  }
+
+  notice.write(next);
+  const commit = await gitrepo.commitAndPush(`Notice: ${sub} via Telegram`);
+  let reply = `${what}\n\n${notice.describe(notice.read())}`;
+  reply += commit
+    ? `\n\n— Pushed to ${config.agentBranch}; live once the site redeploys.`
+    : '\n\n— Already in that state, nothing to push.';
+  await telegram.sendMessage(msg.chat.id, reply);
 }
 
 async function onMessage(msg) {
@@ -110,6 +179,8 @@ async function onMessage(msg) {
       await runJob(msg, 'llm-index', jobs.runLlmIndex);
     } else if (text === '/llmusage') {
       await runJob(msg, 'llm-usage', jobs.runLlmUsage);
+    } else if (text === '/notice' || text.startsWith('/notice ')) {
+      await handleNotice(msg, text.slice('/notice'.length).trim());
     } else if (text === '/approve') {
       if (!config.allowApprove) {
         await telegram.sendMessage(msg.chat.id, '/approve is disabled (set AGENT_ALLOW_APPROVE=true to enable). Merge the branch on GitHub instead.');
@@ -186,7 +257,14 @@ async function main() {
   await telegram.poll(onMessage);
 }
 
-main().catch((err) => {
-  console.error('Fatal:', err);
-  process.exit(1);
-});
+// Guarded so the message handlers can be required from a test without the
+// bot starting to poll. The entrypoint runs `node /app/agent/index.js`, so
+// this holds in production.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}
+
+module.exports = { onMessage, handleNotice };

--- a/agent/notice.js
+++ b/agent/notice.js
@@ -1,0 +1,74 @@
+// The flash-notice banner on the two home pages. Exactly one notice exists at
+// a time — it is a single JSON file, not a list — and src/site/assets/js/notice.js
+// fetches it at runtime, so a change goes live with the next deploy.
+//
+// The dashboard's Notice tab writes the same file through its own copy of this
+// logic in dashboard/lib/dashlib.js. The agent deliberately keeps a separate
+// copy instead of requiring that module: dashboard/ is an Electron app, and the
+// mai-agent image only rebuilds on changes under agent/, so a dependency added
+// over there would break this bot at runtime long after the change landed. The
+// two must agree on the file shape — change one, change the other.
+const fs = require('fs');
+const path = require('path');
+const { config } = require('./config');
+const { nowInZone } = require('./scheduler');
+
+const NOTICE_REL = 'src/site/content/notice.json';
+const EMPTY = { active: false, until: null, en: '', sv: '' };
+
+function noticeFile() {
+  return path.join(config.repoDir, NOTICE_REL);
+}
+
+function read() {
+  const file = noticeFile();
+  if (!fs.existsSync(file)) return { ...EMPTY };
+  try {
+    return { ...EMPTY, ...JSON.parse(fs.readFileSync(file, 'utf8')) };
+  } catch {
+    // A corrupt file should not wedge the bot; the banner is never load-bearing.
+    return { ...EMPTY };
+  }
+}
+
+function write(notice) {
+  const clean = {
+    active: Boolean(notice.active),
+    until: notice.until ? String(notice.until) : null,
+    en: String(notice.en || ''),
+    sv: String(notice.sv || ''),
+  };
+  if (clean.until && !/^\d{4}-\d{2}-\d{2}$/.test(clean.until)) {
+    throw new Error(`"until" must be a YYYY-MM-DD date, got: ${clean.until}`);
+  }
+  fs.mkdirSync(path.dirname(noticeFile()), { recursive: true });
+  fs.writeFileSync(noticeFile(), JSON.stringify(clean, null, 2) + '\n', 'utf8');
+  return clean;
+}
+
+// True when a notice is switched on but its "until" date has already passed —
+// the banner is configured yet invisible, which is easy to do from the
+// dashboard and impossible to see from Telegram without being told.
+function isExpired(notice) {
+  if (!notice.active || !notice.until) return false;
+  return nowInZone().date > notice.until;
+}
+
+function describe(notice) {
+  const lines = [];
+  if (isExpired(notice)) {
+    lines.push(`Notice: ON but NOT VISIBLE — it expired ${notice.until}.`);
+    lines.push('Send /notice post to clear the date and put it back up.');
+  } else {
+    lines.push(`Notice: ${notice.active ? 'live on the site' : 'not posted'}`);
+  }
+  lines.push('');
+  lines.push(`EN: ${notice.en || '(empty)'}`);
+  lines.push(`SV: ${notice.sv || '(empty)'}`);
+  if (notice.until && !isExpired(notice)) {
+    lines.push(`Expires: ${notice.until} (set from the dashboard)`);
+  }
+  return lines.join('\n');
+}
+
+module.exports = { read, write, describe, isExpired, EMPTY, NOTICE_REL };

--- a/agent/test/notice.test.js
+++ b/agent/test/notice.test.js
@@ -1,0 +1,131 @@
+// Node-only test of the /notice command flow, run against a throwaway repo
+// directory with Telegram and git stubbed out.
+// Run from the repo root:  npm test
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Point the agent at a scratch repo before config.js reads REPO_DIR, and seed
+// it with the shape the dashboard leaves behind: switched on, but with an
+// "until" date that has already passed.
+const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-notice-'));
+fs.mkdirSync(path.join(repo, 'src/site/content'), { recursive: true });
+const noticePath = path.join(repo, 'src/site/content/notice.json');
+const YESTERDAY = new Date(Date.now() - 864e5).toISOString().slice(0, 10);
+const seed = { active: true, until: YESTERDAY, en: 'Andon Labs lecture series', sv: 'Andon Labs föreläsningsserie' };
+fs.writeFileSync(noticePath, JSON.stringify(seed, null, 2));
+
+process.env.REPO_DIR = repo;
+process.env.TELEGRAM_CHAT_ID = '99';
+process.env.TELEGRAM_ALLOWED_USER_IDS = '42';
+
+// Replace telegram/gitrepo in the module cache so requiring index.js neither
+// talks to Telegram nor touches a real clone.
+const sent = [];
+let pushes = 0;
+require.cache[require.resolve('../telegram')] = {
+  id: 'stub-telegram', filename: 'stub-telegram', loaded: true, children: [], paths: [],
+  exports: { sendMessage: async (_chatId, text) => { sent.push(text); }, poll: async () => {} },
+};
+require.cache[require.resolve('../gitrepo')] = {
+  id: 'stub-gitrepo', filename: 'stub-gitrepo', loaded: true, children: [], paths: [],
+  exports: {
+    pull: async () => {},
+    commitAndPush: async () => { pushes += 1; return 'abc1234 Notice'; },
+    setup: async () => {},
+    status: async () => ({ branch: 'main', last: 'abc1234 seed', dirty: '' }),
+  },
+};
+
+const { onMessage } = require('../index');
+const notice = require('../notice');
+
+const msg = (text) => ({ text, chat: { id: '99' }, from: { id: '42' } });
+const onDisk = () => JSON.parse(fs.readFileSync(noticePath, 'utf8'));
+const last = () => sent[sent.length - 1] || '';
+function reset() { sent.length = 0; pushes = 0; }
+
+(async () => {
+  // A notice left active past its date is configured but invisible. /notice
+  // has to say so, because nothing else in Telegram reveals it.
+  reset();
+  await onMessage(msg('/notice'));
+  assert.match(last(), /NOT VISIBLE/, '/notice did not flag the expired notice');
+  assert.match(last(), new RegExp(YESTERDAY), '/notice did not name the expiry date');
+  assert.strictEqual(pushes, 0, 'reading the notice should not push');
+
+  // Posting clears the stale date — this is the whole reason durations stay
+  // out of Telegram: post means "up until I remove it".
+  reset();
+  await onMessage(msg('/notice post'));
+  assert.strictEqual(onDisk().active, true, 'post did not activate');
+  assert.strictEqual(onDisk().until, null, 'post did not clear until');
+  assert.strictEqual(pushes, 1, 'post did not push exactly once');
+  assert.match(last(), /cleared/, 'post did not mention the cleared date');
+
+  // Content sets both languages; the sv subcommand corrects only Swedish.
+  reset();
+  await onMessage(msg('/notice content Doors open at 18:00'));
+  assert.strictEqual(onDisk().en, 'Doors open at 18:00');
+  assert.strictEqual(onDisk().sv, 'Doors open at 18:00', 'content should fill sv too');
+
+  reset();
+  await onMessage(msg('/notice sv Dörrarna öppnar 18:00'));
+  assert.strictEqual(onDisk().en, 'Doors open at 18:00', 'sv must not touch English');
+  assert.strictEqual(onDisk().sv, 'Dörrarna öppnar 18:00');
+
+  // Removing keeps the text so it can be put back up.
+  reset();
+  await onMessage(msg('/notice remove'));
+  assert.strictEqual(onDisk().active, false, 'remove did not deactivate');
+  assert.strictEqual(onDisk().en, 'Doors open at 18:00', 'remove must keep the text');
+
+  // Removing again is a no-op rather than an empty commit.
+  reset();
+  await onMessage(msg('/notice remove'));
+  assert.strictEqual(pushes, 0, 'removing twice should not push');
+  assert.match(last(), /Nothing is posted/);
+
+  // Guards: no text to set, and nothing to post.
+  reset();
+  await onMessage(msg('/notice content'));
+  assert.strictEqual(pushes, 0, 'empty content should not push');
+  assert.match(last(), /Send the text/);
+
+  fs.writeFileSync(noticePath, JSON.stringify({ active: false, until: null, en: '', sv: '' }));
+  reset();
+  await onMessage(msg('/notice post'));
+  assert.strictEqual(pushes, 0, 'posting empty text should not push');
+  assert.match(last(), /Nothing to post/);
+
+  reset();
+  await onMessage(msg('/notice enable'));
+  assert.strictEqual(pushes, 0);
+  assert.match(last(), /Unknown notice command/);
+
+  // A prefix match must not swallow a different command.
+  reset();
+  await onMessage(msg('/noticeboard'));
+  assert.match(last(), /Unknown command/, '/noticeboard was captured by /notice');
+
+  // The banner is never load-bearing: a corrupt file must not wedge the bot.
+  fs.writeFileSync(noticePath, '{ not json');
+  reset();
+  await onMessage(msg('/notice'));
+  assert.match(last(), /not posted/, 'corrupt notice.json was not handled');
+
+  // The file shape is shared with dashboard/lib/dashlib.js, which validates
+  // the same way.
+  assert.throws(
+    () => notice.write({ active: true, until: '20 July', en: 'x', sv: 'x' }),
+    /YYYY-MM-DD/,
+    'write() accepted a malformed until date',
+  );
+
+  fs.rmSync(repo, { recursive: true, force: true });
+  console.log('notice.test.js: all checks passed');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/dashboard/lib/dashlib.js
+++ b/dashboard/lib/dashlib.js
@@ -86,6 +86,11 @@ function writeSettings(repo, settingsObj) {
 
 // ---------- Flash notice ----------
 
+// agent/notice.js writes this same file for the Telegram /notice commands and
+// keeps its own copy of this logic, because the agent image cannot depend on
+// this Electron app. The file shape below is the shared contract — change it
+// here and you must change it there too.
+
 const NOTICE_REL = 'src/site/content/notice.json';
 const EMPTY_NOTICE = { active: false, until: null, en: '', sv: '' };
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "slides:add": "node tools/slides-add.js",
     "slides:remove": "node tools/slides-remove.js",
     "audit": "lighthouse http://localhost:3000 --output=json --output-path=reports/lighthouse.json",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node agent/test/notice.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Posting a flash notice meant opening the dashboard. These commands cover the three things worth doing from a phone.

```
/notice                  what is up right now
/notice content <text>   set the text, both languages
/notice sv <text>        correct the Swedish
/notice post             put it up
/notice remove           take it down
```

There is one notice, stored in one file, so the commands edit a single record rather than managing a list.

## Decisions worth reviewing

**`post` clears `until`.** Durations otherwise stay in the dashboard. Without this, posting would appear to work and show nothing, because `notice.js` hides a banner whose date has passed — which is the state production is in right now (`active: true`, `until: 2026-07-20`, so the banner is configured and invisible). Clearing it makes "post" read as "up until I remove it". `/notice` says so explicitly when it finds a notice switched on but out of date.

**`remove` keeps the text**, so `/notice post` puts the same notice back without retyping. That assumes a notice comes down because the event passed, not because the wording was wrong.

**`content` fills both languages**, so Swedish shows English until `/notice sv` is sent. The reply says so, but it will not block posting. The alternative was an LLM translation on the critical path of a banner you are posting because something is time-sensitive.

**These push straight to production.** The agent's `AGENT_BRANCH` is `main` — confirmed on the running container — so a notice change deploys like any other content push. No preview step.

## Structure

The agent keeps its own copy of the read/write logic rather than requiring `dashboard/lib/dashlib.js`, which writes the same file. The dashboard is an Electron app, and the mai-agent image only rebuilds on changes under `agent/` — a dependency added there would break the bot at runtime long after the change landed, and `/app/dashboard` is in fact absent from the currently running image for exactly that reason. Both files carry a comment saying the shape must stay in sync.

`main()` is now behind a `require.main` guard so the handlers can be required by a test without the bot starting to poll. The entrypoint runs `node /app/agent/index.js`, so production is unaffected.

## Tests

`npm test` now runs `agent/test/notice.test.js` — 14 assertions with Telegram and git stubbed, against a throwaway repo directory. Covers the state transitions, the guards (`/notice post` with no text, `/notice remove` when nothing is up — neither pushes an empty commit), a corrupt `notice.json`, that `/noticeboard` is not swallowed by the `/notice` prefix, and that a malformed `until` is rejected.

## Also here

`.dockerignore` excluded only top-level `node_modules`, so `dashboard/node_modules` (Electron, a few hundred MB) was being copied into both images. It went unnoticed because the dashboard landed after the agent image last built; this branch touches `agent/**`, which triggers the rebuild that would have pulled it in. Verified on the engine that builds these images.

## After merging

Production's notice is still invisible. Merging does not fix it — send `/notice post` once deployed, or clear the date in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
