### PR TITLE
Stop the AI-news job from repeating yesterday's lead story

### DIFF
--- a/agent/jobs.js
+++ b/agent/jobs.js
@@ -127,6 +127,31 @@ function postExists(dateIso, type) {
   return fs.existsSync(postPath(dateIso, type, 'en'));
 }
 
+// Titles of the most recent published posts of a type, strictly before
+// beforeIso, newest first. Scans the directory (rather than just checking
+// "yesterday") so a skipped day doesn't hide the last real post.
+function recentPostTitles(type, { limit = 2, beforeIso } = {}) {
+  const dir = DAILY_DIR();
+  if (!fs.existsSync(dir)) return [];
+  const re = new RegExp(`^(\\d{4}-\\d{2}-\\d{2})\\.${type}\\.en\\.html$`);
+  return fs
+    .readdirSync(dir)
+    .map((f) => {
+      const m = f.match(re);
+      return m ? { date: m[1], file: f } : null;
+    })
+    .filter((d) => d && (!beforeIso || d.date < beforeIso))
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, limit)
+    .map((d) => {
+      const html = fs.readFileSync(path.join(dir, d.file), 'utf8');
+      const m = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
+      const title = m ? m[1].replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim() : '';
+      return title ? { date: d.date, title } : null;
+    })
+    .filter(Boolean);
+}
+
 async function publishPost(dateIso, type, post, commitMessage) {
   fs.mkdirSync(DAILY_DIR(), { recursive: true });
   fs.writeFileSync(postPath(dateIso, type, 'en'), post.html_en.trim() + '\n', 'utf8');
@@ -182,11 +207,21 @@ async function runAiNews({ force = false, topic = '' } = {}) {
   const steer = topic
     ? `\nThe museum's editor has requested that the LEAD story of today's briefing be: "${topic}". Research it, make it the opening item with the most depth, and cover other significant AI news after it.`
     : '';
+
+  // Multi-day stories (a launch that keeps generating coverage) can look
+  // like "today's top news" on consecutive mornings with no other signal.
+  // Tell the model what it already led with so it doesn't repeat itself.
+  const recent = recentPostTitles('ainews', { limit: 2, beforeIso: iso });
+  const recentLeads = recent.length
+    ? `\nThe lead stor${recent.length === 1 ? 'y' : 'ies'} from your last ${recent.length} AI news briefing${recent.length === 1 ? '' : 's'} ${recent.length === 1 ? 'was' : 'were'}:\n${recent.map((r) => `- "${r.title}" (${r.date})`).join('\n')}\nDo not lead with the same story again unless something materially new and significant has happened since — if so, frame it explicitly as a fresh development ("update:", a new number, a new decision), not a recap. If it's still relevant but not today's biggest development, cover it briefly as a non-lead item instead of opening with it.\n`
+    : '';
+
   const prompt = prompts.render('ai-news', {
     readable,
     readableSv,
     year: iso.slice(0, 4),
     steer,
+    recentLeads,
     ...sharedRules(),
   });
 
@@ -236,4 +271,8 @@ async function runLlmUsage() {
   );
 }
 
-module.exports = { runOnThisDay, runAiNews, runLlmIndex, runLlmUsage, todayParts };
+// recentPostTitles is exported for tests: it matches post filenames by
+// pattern, so if the naming convention in publishPost ever changes it would
+// quietly return nothing and the repeat-avoidance would stop working with no
+// visible symptom.
+module.exports = { runOnThisDay, runAiNews, runLlmIndex, runLlmUsage, todayParts, recentPostTitles };

--- a/agent/prompts/ai-news.md
+++ b/agent/prompts/ai-news.md
@@ -1,5 +1,5 @@
 Today is {{readable}} {{year}}. Use web search to find the most significant AI news from the last 24-48 hours, then write a daily AI news summary (350-500 words) for the Museum of Artificial Intelligence's general-audience readers.{{steer}}
-
+{{recentLeads}}
 Cover a mix of what actually happened (skip categories with no real news): research breakthroughs, product releases, laws and regulation, business and finance, and notable public debate.
 
 Requirements:

--- a/agent/test/ainews-lead.test.js
+++ b/agent/test/ainews-lead.test.js
@@ -1,0 +1,77 @@
+// Node-only test of the AI-news repeat-avoidance helper, run against a
+// throwaway repo directory. Run from the repo root:  npm test
+//
+// The helper finds previous posts by matching filenames, so the thing most
+// worth pinning down is that it matches the names publishPost actually
+// writes. If those drift apart it returns nothing, the prompt loses its
+// "don't lead with this again" section, and the only symptom is a briefing
+// that repeats itself weeks later.
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-ainews-'));
+const daily = path.join(repo, 'src', 'content', 'daily');
+fs.mkdirSync(daily, { recursive: true });
+process.env.REPO_DIR = repo;
+
+const post = (date, type, title) => {
+  // Same shape publishPost writes: <date>.<type>.<locale>.html
+  fs.writeFileSync(
+    path.join(daily, `${date}.${type}.en.html`),
+    `<article><h1 class="post-title">${title}</h1><p>body</p></article>\n`,
+  );
+  fs.writeFileSync(path.join(daily, `${date}.${type}.sv.html`), '<article><h1>svensk</h1></article>\n');
+};
+
+post('2026-07-18', 'ainews', 'Moonshot AI ships Kimi K3');
+post('2026-07-19', 'ainews', 'Kimi K3 lands in Europe');
+post('2026-07-20', 'ainews', 'EU opens an inquiry');
+post('2026-07-20', 'onthisday', 'The perceptron turns 68');
+
+const { recentPostTitles } = require('../jobs');
+
+// Newest first, limited, and strictly before the requested date — today's own
+// post must never be fed back as a previous lead.
+const recent = recentPostTitles('ainews', { limit: 2, beforeIso: '2026-07-21' });
+assert.strictEqual(recent.length, 2, `expected 2 recent leads, got ${recent.length}`);
+assert.deepStrictEqual(
+  recent.map((r) => r.date),
+  ['2026-07-20', '2026-07-19'],
+  'recent leads are not newest-first',
+);
+assert.strictEqual(recent[0].title, 'EU opens an inquiry', 'title not extracted from the h1');
+
+// Types must not bleed into each other.
+assert.ok(
+  !recent.some((r) => /perceptron/i.test(r.title)),
+  'an on-this-day post leaked into the AI-news leads',
+);
+const onthisday = recentPostTitles('onthisday', { limit: 2, beforeIso: '2026-07-21' });
+assert.strictEqual(onthisday.length, 1);
+assert.strictEqual(onthisday[0].title, 'The perceptron turns 68');
+
+// A gap in publishing must not hide the last real post — this is why the
+// helper scans the directory instead of just looking at yesterday.
+const acrossGap = recentPostTitles('ainews', { limit: 1, beforeIso: '2026-07-25' });
+assert.strictEqual(acrossGap[0].date, '2026-07-20', 'a publishing gap hid the previous lead');
+
+// Regenerating today's post must not see itself.
+post('2026-07-21', 'ainews', 'Today, freshly written');
+const excludingToday = recentPostTitles('ainews', { limit: 2, beforeIso: '2026-07-21' });
+assert.ok(
+  !excludingToday.some((r) => r.date === '2026-07-21'),
+  "today's own post was offered back as a previous lead",
+);
+
+// No history at all is a normal first run, not an error.
+const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-ainews-empty-'));
+process.env.REPO_DIR = empty;
+delete require.cache[require.resolve('../jobs')];
+delete require.cache[require.resolve('../config')];
+assert.deepStrictEqual(require('../jobs').recentPostTitles('ainews', { limit: 2 }), []);
+
+fs.rmSync(repo, { recursive: true, force: true });
+fs.rmSync(empty, { recursive: true, force: true });
+console.log('ainews-lead.test.js: all checks passed');

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "slides:add": "node tools/slides-add.js",
     "slides:remove": "node tools/slides-remove.js",
     "audit": "lighthouse http://localhost:3000 --output=json --output-path=reports/lighthouse.json",
-    "test": "node agent/test/notice.test.js"
+    "test": "node agent/test/notice.test.js && node agent/test/ainews-lead.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Re-lands the agent changes from #18, which was closed because it also carried unrelated `slides.json` and slide-image deletions. `agent/jobs.js` and `agent/prompts/ai-news.md` are taken unchanged from that branch — main had not touched either file since it diverged, so this is the same fix with nothing else attached.

## The problem

`runAiNews` has never had any memory of what it published before. Each morning it asks the model for "the most significant AI news from the last 24-48 hours" with no awareness of prior posts, so a story that keeps generating coverage can look like the top story on consecutive mornings. That is how 07-18 and 07-19 both led with the Kimi K3 launch — the rest of each briefing was genuinely different, only the lead repeated.

## The fix

The job now passes the last two lead headlines into the prompt and asks the model not to repeat them unless something materially new has happened, in which case it should frame it as a fresh development rather than a recap.

`recentPostTitles` scans the daily directory rather than just checking yesterday, so a skipped day doesn't hide the last real post, and it excludes the date being written so regenerating today's post doesn't feed the post back to itself.

## Added on top of #18

The helper is now exported and covered by `agent/test/ainews-lead.test.js`.

It finds previous posts by matching filenames against what `publishPost` writes. If those two ever drift apart it returns nothing, the prompt silently loses its repeat-avoidance section, and the only symptom is a briefing that repeats itself — weeks later, with nothing in the logs. The test pins the filename convention along with newest-first ordering, the before-date exclusion, that on-this-day posts don't leak into the news leads, and that a publishing gap doesn't hide the previous lead.

## Verified

- `npm test` passes both agent test files.
- The prompt renders correctly with history (the leads section appears, no placeholder left behind) and without it (identical to the current prompt). Worth noting: `prompts.render` throws on unknown placeholders, so a missing variable would fail the job loudly rather than sending `{{recentLeads}}` to the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
