### PR TITLE
Register the command menu with Telegram

### DIFF
--- a/agent/index.js
+++ b/agent/index.js
@@ -52,6 +52,29 @@ Expiry dates stay in the dashboard; /notice post clears any date it finds.
 
 Edits are committed to ${config.agentBranch} and deploy to ${config.previewUrl || 'the site'}.`;
 
+// What Telegram offers in the "/" menu. Only top-level commands exist as far
+// as Telegram is concerned, so /notice carries its subcommands in the
+// description. Ordered by how often they get used, since that is the order
+// the menu shows. Keep in step with HELP — a test asserts they agree.
+const COMMANDS = [
+  { command: 'notice', description: 'Flash notice — /notice, content <text>, sv <text>, post, remove' },
+  { command: 'status', description: 'Branch, last commit, pending changes' },
+  { command: 'news', description: 'Run the AI news summary now (/news <topic> to steer the lead)' },
+  { command: 'ontoday', description: 'Run the "on this day" essay now (/ontoday <event> to steer it)' },
+  { command: 'diff', description: 'Diff stat of the working tree' },
+  { command: 'llmindex', description: 'Refresh the LLM leaderboard card' },
+  { command: 'llmusage', description: 'Refresh the OpenRouter usage card' },
+  { command: 'help', description: 'What I can do' },
+];
+
+// /approve is only listed when it is actually enabled — offering a command
+// that answers "that is disabled" is worse than not offering it.
+function menuCommands() {
+  return config.allowApprove
+    ? [...COMMANDS, { command: 'approve', description: `Merge ${config.agentBranch} into ${config.mainBranch}` }]
+    : COMMANDS;
+}
+
 async function handleEdit(msg, instruction) {
   await telegram.sendMessage(msg.chat.id, 'Working on it…');
   await gitrepo.pull().catch(() => {});
@@ -205,6 +228,15 @@ async function main() {
   const s = await gitrepo.status();
   console.log(`Agent starting on branch ${s.branch} (${s.last}) in ${config.repoDir}`);
 
+  // Cosmetic, and Telegram is a third party that can be having a bad day —
+  // never let this stop the bot from coming up.
+  try {
+    await telegram.setCommands(menuCommands());
+    console.log(`Registered ${menuCommands().length} commands with Telegram.`);
+  } catch (err) {
+    console.warn('Could not register the Telegram command menu:', err.message);
+  }
+
   startScheduler(
     [
       // Scheduled runs are silent on success — Telegram only carries replies
@@ -267,4 +299,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { onMessage, handleNotice };
+module.exports = { onMessage, handleNotice, COMMANDS, menuCommands, HELP };

--- a/agent/telegram.js
+++ b/agent/telegram.js
@@ -78,4 +78,11 @@ async function poll(onMessage, { signal } = {}) {
   }
 }
 
-module.exports = { sendMessage, poll, escapeHtml };
+// Register the command list Telegram shows in the "/" menu. Purely cosmetic —
+// the bot answers a command whether or not it is registered — so a failure
+// here must never stop the agent from starting.
+async function setCommands(commands) {
+  return api('setMyCommands', { commands });
+}
+
+module.exports = { sendMessage, poll, escapeHtml, setCommands };

--- a/agent/test/commands.test.js
+++ b/agent/test/commands.test.js
@@ -1,0 +1,94 @@
+// Node-only test of the Telegram command menu. Run from the repo root: npm test
+//
+// The menu is what people see when they type "/" on a phone, so the failure
+// that matters is advertising a command the bot does not answer. Everything
+// here is offline: telegram, git and the content jobs are stubbed, so running
+// the suite never posts, pushes, or calls a model.
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'mai-commands-'));
+fs.mkdirSync(path.join(repo, 'src/site/content'), { recursive: true });
+fs.writeFileSync(
+  path.join(repo, 'src/site/content/notice.json'),
+  JSON.stringify({ active: false, until: null, en: 'text', sv: 'text' }),
+);
+process.env.REPO_DIR = repo;
+process.env.TELEGRAM_CHAT_ID = '99';
+process.env.TELEGRAM_ALLOWED_USER_IDS = '42';
+
+const sent = [];
+require.cache[require.resolve('../telegram')] = {
+  id: 'stub-telegram', filename: 'stub-telegram', loaded: true, children: [], paths: [],
+  exports: {
+    sendMessage: async (_chatId, text) => { sent.push(text); },
+    poll: async () => {},
+    setCommands: async () => true,
+  },
+};
+require.cache[require.resolve('../gitrepo')] = {
+  id: 'stub-gitrepo', filename: 'stub-gitrepo', loaded: true, children: [], paths: [],
+  exports: {
+    pull: async () => {}, commitAndPush: async () => 'abc1234 stub', setup: async () => {},
+    status: async () => ({ branch: 'main', last: 'abc1234 stub', dirty: '' }),
+    diffStat: async () => 'stub diff',
+  },
+};
+// Stubbed so that exercising /news and friends cannot reach a model.
+const stubJob = async () => ({ skipped: true, reason: 'stubbed' });
+require.cache[require.resolve('../jobs')] = {
+  id: 'stub-jobs', filename: 'stub-jobs', loaded: true, children: [], paths: [],
+  exports: { runOnThisDay: stubJob, runAiNews: stubJob, runLlmIndex: stubJob, runLlmUsage: stubJob },
+};
+
+const { onMessage, COMMANDS, menuCommands, HELP } = require('../index');
+const { config } = require('../config');
+
+// Telegram's own constraints on setMyCommands.
+for (const { command, description } of COMMANDS) {
+  assert.match(command, /^[a-z0-9_]{1,32}$/, `"${command}" is not a legal Telegram command name`);
+  assert.ok(description.length >= 1 && description.length <= 256, `"${command}" description is out of range`);
+}
+const names = COMMANDS.map((c) => c.command);
+assert.strictEqual(new Set(names).size, names.length, 'duplicate command in the menu');
+
+// The menu and /help are two lists of the same thing; drift is invisible
+// until someone follows one of them and it does not work.
+for (const name of names) {
+  assert.ok(HELP.includes(`/${name}`), `/${name} is in the Telegram menu but missing from /help`);
+}
+
+// /approve is listed only when it is enabled.
+config.allowApprove = false;
+assert.ok(!menuCommands().some((c) => c.command === 'approve'), '/approve listed while disabled');
+config.allowApprove = true;
+assert.ok(menuCommands().some((c) => c.command === 'approve'), '/approve missing while enabled');
+config.allowApprove = false;
+
+// The point of the whole file: every advertised command must be handled.
+(async () => {
+  for (const name of names) {
+    sent.length = 0;
+    await onMessage({ text: `/${name}`, chat: { id: '99' }, from: { id: '42' } });
+    const reply = sent.join('\n');
+    assert.ok(reply.length > 0, `/${name} produced no reply at all`);
+    assert.ok(
+      !/^Unknown command/.test(reply),
+      `/${name} is advertised in the menu but the dispatch does not handle it`,
+    );
+  }
+
+  // Control: something not in the menu still falls through to the edit path's
+  // unknown-command branch, so the assertion above is actually discriminating.
+  sent.length = 0;
+  await onMessage({ text: '/notacommand', chat: { id: '99' }, from: { id: '42' } });
+  assert.match(sent.join('\n'), /^Unknown command/, 'unknown commands no longer report as unknown');
+
+  fs.rmSync(repo, { recursive: true, force: true });
+  console.log(`commands.test.js: all checks passed (${names.length} commands)`);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/agent/test/run.js
+++ b/agent/test/run.js
@@ -1,0 +1,29 @@
+// Runs every *.test.js in this directory, each in its own process so the
+// agent's module cache and REPO_DIR stubbing in one file cannot leak into the
+// next. Exits non-zero on the first failure. Adding a test file is enough to
+// have it run — there is no list to keep up to date.
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const dir = __dirname;
+const files = fs
+  .readdirSync(dir)
+  .filter((f) => f.endsWith('.test.js'))
+  .sort();
+
+if (files.length === 0) {
+  console.error('No test files found in', dir);
+  process.exit(1);
+}
+
+for (const file of files) {
+  try {
+    execFileSync(process.execPath, [path.join(dir, file)], { stdio: 'inherit' });
+  } catch {
+    console.error(`\nFAILED: ${file}`);
+    process.exit(1);
+  }
+}
+
+console.log(`\n${files.length} test file(s) passed.`);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "slides:add": "node tools/slides-add.js",
     "slides:remove": "node tools/slides-remove.js",
     "audit": "lighthouse http://localhost:3000 --output=json --output-path=reports/lighthouse.json",
-    "test": "node agent/test/notice.test.js"
+    "test": "node agent/test/run.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The bot has never called `setMyCommands`, so typing "/" in the chat offers nothing — every command has to be remembered or dug out of `/help`. That is worst on a phone, which is where the `/notice` commands are meant to be used. `getMyCommands` against the live bot currently returns `[]`.

## What it registers

```
/notice     Flash notice — /notice, content <text>, sv <text>, post, remove
/status     Branch, last commit, pending changes
/news       Run the AI news summary now (/news <topic> to steer the lead)
/ontoday    Run the "on this day" essay now (/ontoday <event> to steer it)
/diff       Diff stat of the working tree
/llmindex   Refresh the LLM leaderboard card
/llmusage   Refresh the OpenRouter usage card
/help       What I can do
```

Only top-level commands exist as far as Telegram is concerned, so `/notice` carries its subcommands in its description. Ordered by expected use, since that is the order the menu shows.

`/approve` is appended only when `AGENT_ALLOW_APPROVE` is set — offering a command that answers "that is disabled" is worse than not offering it.

## Failure behaviour

Registration happens once at startup, wrapped in try/catch. The menu is cosmetic — the bot answers a command whether or not it is registered — and Telegram is a third party that can be having a bad day. Neither should stop the agent from coming up; a failure logs a warning and the bot carries on.

## Tests

`agent/test/commands.test.js` covers:

- Telegram's own constraints on command names and description length, and no duplicates.
- That the menu and `/help` do not drift apart — two lists of the same thing, where drift is invisible until someone follows one and it does not work.
- That `/approve` appears only when enabled.
- The point of the file: every advertised command is actually handled by the dispatch, with a control case (`/notacommand`) proving the assertion discriminates rather than passing vacuously.

The content jobs are stubbed alongside telegram and git, so running the suite never posts, pushes, or reaches a model.

`npm test` now runs `agent/test/run.js`, which executes every `*.test.js` in that directory in its own process — module-cache and `REPO_DIR` stubbing in one file cannot leak into the next, and adding a test file is enough to have it run.

## Note on merge order

This and #24 both edit the `test` script line in `package.json`, so whichever merges second will conflict there. Resolve by keeping `node agent/test/run.js` — it discovers `ainews-lead.test.js` from #24 automatically, no list to maintain.

I did not call `setMyCommands` against the live bot by hand; the menu appears when this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Telegram command menu for easier bot navigation.
  * The `/approve` command appears only when enabled.
  * Command menus are registered automatically when the bot starts.

* **Bug Fixes**
  * Bot startup continues if Telegram rejects command-menu registration.

* **Tests**
  * Added coverage for command menus, help output, command handling, and unknown commands.
  * Test execution now automatically discovers and runs all test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->