### PR TITLE
Redirect trailing-slash clean URLs to their canonical path

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -47,7 +47,17 @@ app.use((req, res, next) => {
   if (req.method !== "GET" && req.method !== "HEAD") return next();
   if (req.path.startsWith("/api/") || path.extname(req.path)) return next();
   const file = resolvePublic(req.path, ".html");
-  if (file && fs.existsSync(file)) return res.sendFile(file);
+  if (file && fs.existsSync(file)) {
+    // /pages/daily/ must not serve daily.html as-is: the page's relative
+    // paths (../assets, daily/…) would resolve one level too deep, leaving it
+    // unstyled with dead edition links. Send the browser to the canonical
+    // slash-less URL first so the base is right.
+    if (req.path.length > 1 && req.path.endsWith("/")) {
+      const query = req.originalUrl.slice(req.path.length);
+      return res.redirect(301, req.path.replace(/\/+$/, "") + query);
+    }
+    return res.sendFile(file);
+  }
   next();
 });
 


### PR DESCRIPTION
`https://aimuseum.se/pages/daily/` returned 200 with the correct HTML, but rendered broken: the browser kept `/pages/daily/` as the base, so the page's relative paths resolved one level too deep.

- `../assets/css/{tailwind,styles}.css` → `/pages/assets/...` — unstyled page
- `daily/2026-07-21-ainews.html` → `/pages/daily/daily/...` — every edition link dead

The clean-URL middleware served `daily.html` for the trailing-slash form instead of redirecting, so the wrong base stuck.

## Fix

301 to the slash-less URL when a trailing-slash request maps to an `.html` file, preserving any query string.

## Verified locally

| URL | Result |
| --- | --- |
| `/pages/daily/` | 301 → `/pages/daily` |
| `/pages/events/` | 301 → `/pages/events` |
| `/sv/pages/daily/` | 301 → `/sv/pages/daily` |
| `/pages/daily/?x=1` | 301 → `/pages/daily?x=1` |
| `/sv` | 301 → `/sv/` (unchanged) |
| `/pages/` | 404 page (unchanged) |

After the redirect, stylesheets resolve to `/assets/css/*`, edition links to `/pages/daily/2026-07-21-ainews.html`, dark theme renders, no console errors.

Only four paths in `public/` have a directory beside a same-named `.html` (`pages/daily`, `pages/events`, and their `sv/` twins) — all covered. No directory has both an `index.html` and an `.html` sibling, so real directory indexes like `/sv` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clean URL handling by redirecting trailing-slash requests to a canonical slash-less URL.
  * Preserved query parameters during redirects.
  * Continued serving the corresponding page after URL normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->