### PR TITLE
Link the quiz from both home pages, and stop overpromising new questions

### DIFF
--- a/src/content/pages/quiz.en.html
+++ b/src/content/pages/quiz.en.html
@@ -15,7 +15,7 @@
 
         <section id="quiz-intro" class="glass-card p-6 rounded-xl">
           <h2 class="text-2xl font-bold mb-2">Ready?</h2>
-          <p class="text-slate-400 text-sm md:text-base leading-relaxed mb-5">Ten questions, four options each, drawn at random from a larger set — so it is worth a second try. Nothing you answer leaves your browser, and no score is recorded anywhere.</p>
+          <p class="text-slate-400 text-sm md:text-base leading-relaxed mb-5">Ten questions, four options each, drawn at random from a larger set. Nothing you answer leaves your browser, and no score is recorded anywhere.</p>
           <button type="button" id="quiz-start" class="bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2.5 rounded-lg font-semibold text-sm md:text-base transition duration-300 inline-flex items-center justify-center gap-2">
             <i class="fa-solid fa-play"></i>
             Start the quiz
@@ -37,7 +37,7 @@
           <div class="flex flex-wrap gap-3">
             <button type="button" id="quiz-restart" class="bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2.5 rounded-lg font-semibold text-sm md:text-base transition duration-300 inline-flex items-center justify-center gap-2">
               <i class="fa-solid fa-rotate-right"></i>
-              Try another ten
+              Try again
             </button>
             <a href="explore.html" class="bg-slate-700 hover:bg-slate-600 text-white px-5 py-2.5 rounded-lg font-semibold text-sm md:text-base transition duration-300 inline-flex items-center justify-center gap-2">
               <i class="fa-solid fa-compass"></i>

--- a/src/content/pages/quiz.sv.html
+++ b/src/content/pages/quiz.sv.html
@@ -15,7 +15,7 @@
 
         <section id="quiz-intro" class="glass-card p-6 rounded-xl">
           <h2 class="text-2xl font-bold mb-2">Redo?</h2>
-          <p class="text-slate-400 text-sm md:text-base leading-relaxed mb-5">Tio frågor med fyra alternativ vardera, slumpmässigt valda ur en större uppsättning — så det är värt ett andra försök. Inget du svarar lämnar din webbläsare, och inget resultat sparas någonstans.</p>
+          <p class="text-slate-400 text-sm md:text-base leading-relaxed mb-5">Tio frågor med fyra alternativ vardera, slumpmässigt valda ur en större uppsättning. Inget du svarar lämnar din webbläsare, och inget resultat sparas någonstans.</p>
           <button type="button" id="quiz-start" class="bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2.5 rounded-lg font-semibold text-sm md:text-base transition duration-300 inline-flex items-center justify-center gap-2">
             <i class="fa-solid fa-play"></i>
             Starta testet
@@ -37,7 +37,7 @@
           <div class="flex flex-wrap gap-3">
             <button type="button" id="quiz-restart" class="bg-indigo-600 hover:bg-indigo-700 text-white px-5 py-2.5 rounded-lg font-semibold text-sm md:text-base transition duration-300 inline-flex items-center justify-center gap-2">
               <i class="fa-solid fa-rotate-right"></i>
-              Försök med tio nya
+              Försök igen
             </button>
             <a href="explore.html" class="bg-slate-700 hover:bg-slate-600 text-white px-5 py-2.5 rounded-lg font-semibold text-sm md:text-base transition duration-300 inline-flex items-center justify-center gap-2">
               <i class="fa-solid fa-compass"></i>

--- a/src/site/assets/css/home.css
+++ b/src/site/assets/css/home.css
@@ -461,6 +461,7 @@ body {
 .reveal.is-visible { opacity: 1; transform: none; }
 .reveal-d1 { transition-delay: 0.1s; }
 .reveal-d2 { transition-delay: 0.2s; }
+.reveal-d3 { transition-delay: 0.3s; }
 
 /* No-JS and reduced-motion: content is always visible */
 .no-js .reveal { opacity: 1; transform: none; }

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -319,7 +319,7 @@
                     Want us to come to you in the meantime? We tailor sessions for companies, schools, and organizations.
                 </p>
 
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-8">
                     <article class="plaque reveal">
                         <div class="p-7 flex flex-col flex-1">
                             <span class="plaque-label">For your team</span>
@@ -349,6 +349,17 @@
                             <p class="mt-3 flex-1">Essays, event announcements, and independent commentary on where AI is heading — straight to your inbox.</p>
                             <div class="mt-7">
                                 <a href="pages/journal.html" class="link-m">Read the journal <span aria-hidden="true">→</span></a>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="plaque reveal reveal-d3">
+                        <div class="p-7 flex flex-col flex-1">
+                            <span class="plaque-label">Test yourself</span>
+                            <h3>How much do you know?</h3>
+                            <p class="mt-3 flex-1">Ten questions on how AI works, where it came from, and what the terminology actually means — with a short explanation after every answer.</p>
+                            <div class="mt-7">
+                                <a href="pages/quiz.html" class="link-m">Take the test <span aria-hidden="true">→</span></a>
                             </div>
                         </div>
                     </article>

--- a/src/site/sv/index.html
+++ b/src/site/sv/index.html
@@ -320,7 +320,7 @@
                     Vill ni att vi kommer till er under tiden? Vi skräddarsyr för företag, skolor och organisationer.
                 </p>
 
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 lg:gap-8">
                     <article class="plaque reveal">
                         <div class="p-7 flex flex-col flex-1">
                             <span class="plaque-label">För er grupp</span>
@@ -350,6 +350,17 @@
                             <p class="mt-3 flex-1">Essäer, evenemang och oberoende kommentarer om vart AI är på väg — direkt till din inkorg.</p>
                             <div class="mt-7">
                                 <a href="/sv/pages/journal.html" class="link-m">Läs journalen <span aria-hidden="true">→</span></a>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="plaque reveal reveal-d3">
+                        <div class="p-7 flex flex-col flex-1">
+                            <span class="plaque-label">Testa dig själv</span>
+                            <h3>Hur mycket kan du?</h3>
+                            <p class="mt-3 flex-1">Tio frågor om hur AI fungerar, var tekniken kommer ifrån och vad begreppen egentligen betyder — med en kort förklaring efter varje svar.</p>
+                            <div class="mt-7">
+                                <a href="/sv/pages/quiz.html" class="link-m">Gör testet <span aria-hidden="true">→</span></a>
                             </div>
                         </div>
                     </article>


### PR DESCRIPTION
## Copy fix

"Try another ten" / "Försök med tio nya" claimed novelty the bank cannot deliver — with 20 evergreen questions and 10 per round, roughly half repeat. Now **"Try again" / "Försök igen"**. The intro line drops "so it is worth a second try" for the same reason.

## Home-page placement

A fourth plaque in **"Take part" / "Delta"** (Hall 04), beside *Plan a session*, *Become a member* and *Read our newsletter*.

Worth noting for review: these Hall 04 cards carry **no image**, unlike the Hall 01 grid — so the quiz card needed no artwork, which is what made this the cheap option.

The grid widens from `md:grid-cols-3` to `md:grid-cols-2 lg:grid-cols-4`, so four cards sit evenly rather than orphaning the fourth onto its own row. **Hall 01 keeps its three-column layout** — only the Take part grid changed.

`reveal-d3` (0.3s) added to `home.css`: only `d1` and `d2` existed, so a fourth card would otherwise have reused `d2` and broken the stagger.

## Verification

| Viewport | Take part | Hall 01 |
| --- | --- | --- |
| 375 | 1 per row | unchanged |
| 800 | 2 × 2 | 3 across |
| 1440 | 4 across, equal 288px widths and 332px heights | 3 across |

No clipped text, no horizontal overflow at any width. Both home-page links resolve (`/pages/quiz.html`, `/sv/pages/quiz.html` → 200). Swedish card reads "Testa dig själv / Hur mycket kan du? / Gör testet →". `npm test`: 5 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Test yourself” quiz card to the events section in English and Swedish.
  - Updated the events grid to support the expanded set of cards.
  - Added an additional staggered reveal effect for page content.

- **Content Updates**
  - Clarified that quiz questions are selected randomly and answers remain in the browser without recorded scores.
  - Simplified the results-page retry button text in both languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->